### PR TITLE
fix(auth): scope refresh token revocation and invalidate sessions on …

### DIFF
--- a/server/routes/auth_routes.py
+++ b/server/routes/auth_routes.py
@@ -7,7 +7,8 @@ from server.utils.auth_utils import (
     generate_refresh_token,
     decode_token,
     token_required,
-    revoke_refresh_token
+    revoke_refresh_token,
+    revoke_all_user_refresh_tokens,
 )
 from server.utils.validators import (
     validate_registration_data,
@@ -171,8 +172,10 @@ def logout(current_user):
             return jsonify({'success': False, 'error': 'Refresh token is required'}), 400
         
         token = data['refresh_token']
-        revoke_refresh_token(token)
-        
+        # Scope the revocation to the authenticated user so a caller cannot
+        # revoke a refresh token that belongs to a different user.
+        revoke_refresh_token(token, user_id=current_user.id)
+
         return jsonify({'success': True, 'message': 'Logout successful'}), 200
         
     except Exception as e:
@@ -248,8 +251,23 @@ def change_password(current_user):
         
         current_user.set_password(new_password)
         db.session.commit()
-        
-        return jsonify({'success': True, 'message': 'Password changed successfully'}), 200
+
+        # Invalidate every existing refresh token so that any previously-issued
+        # session (including ones an attacker may have exfiltrated) can no
+        # longer be used to mint new access tokens. The caller must log in
+        # again on other devices after changing their password.
+        revoked_count = revoke_all_user_refresh_tokens(current_user.id)
+        logger.info(
+            "Password changed for user_id=%s; revoked %s refresh tokens",
+            current_user.id,
+            revoked_count,
+        )
+
+        return jsonify({
+            'success': True,
+            'message': 'Password changed successfully. Please log in again on your other devices.',
+            'revoked_sessions': revoked_count,
+        }), 200
         
     except Exception as e:
         db.session.rollback()

--- a/server/tests/test_refresh_token_revocation.py
+++ b/server/tests/test_refresh_token_revocation.py
@@ -1,0 +1,184 @@
+"""Regression tests for refresh token revocation helpers.
+
+Covers two security-sensitive behaviours that are used by the auth routes:
+
+1. ``revoke_refresh_token`` must honour the optional ``user_id`` argument so
+   that one authenticated user cannot revoke another user's refresh token.
+
+2. ``revoke_all_user_refresh_tokens`` must revoke every active refresh token
+   for a single user without touching other users' tokens. This is what
+   /change-password calls to invalidate existing sessions.
+"""
+import os
+import sys
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app():
+    """Build a minimal Flask app with an in-memory database for each test."""
+    # Ensure JWT_SECRET_KEY is set before auth_utils is imported.
+    with patch.dict(os.environ, {
+        'JWT_SECRET_KEY': 'test-secret-key-for-testing-only',
+        'SECRET_KEY': 'test-flask-secret-key',
+        'DATABASE_URL': 'sqlite:///:memory:',
+    }):
+        # Force reload so module-level code picks up the env vars.
+        for mod in (
+            'server.utils.auth_utils',
+            'server.middleware.database',
+            'server.models',
+            'server.models.refresh_token',
+            'server.models.user',
+        ):
+            sys.modules.pop(mod, None)
+
+        from server.middleware.database import db
+        # Import models so SQLAlchemy registers the tables before create_all.
+        from server.models import User, RefreshToken  # noqa: F401
+
+        flask_app = Flask(__name__)
+        flask_app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+        flask_app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+        db.init_app(flask_app)
+
+        with flask_app.app_context():
+            db.create_all()
+            yield flask_app
+            db.session.remove()
+            db.drop_all()
+
+
+_TOKEN_COUNTER = {'n': 0}
+
+
+def _make_refresh_token(user_id, username='user', offset_seconds=0):
+    """Insert a RefreshToken row directly with a unique token string.
+
+    The production helper ``generate_refresh_token`` embeds ``iat`` at second
+    precision, which causes UNIQUE collisions when several tokens are issued
+    in the same second. These tests only exercise the revocation helpers, so
+    we just insert a row with a deterministic unique token string.
+    """
+    from server.middleware.database import db
+    from server.models import RefreshToken
+
+    _TOKEN_COUNTER['n'] += 1
+    token_string = f'test-token-{user_id}-{_TOKEN_COUNTER["n"]}'
+    row = RefreshToken(
+        user_id=user_id,
+        token=token_string,
+        expires_at=datetime.utcnow() + timedelta(seconds=3600 + offset_seconds),
+    )
+    db.session.add(row)
+    db.session.commit()
+    return token_string
+
+
+def _count_active_tokens(user_id):
+    from server.models import RefreshToken
+    return RefreshToken.query.filter_by(user_id=user_id, is_revoked=False).count()
+
+
+class TestRevokeRefreshTokenOwnership:
+    """revoke_refresh_token must not revoke tokens owned by other users."""
+
+    def test_revokes_when_user_id_matches(self, app):
+        from server.utils.auth_utils import revoke_refresh_token
+
+        token = _make_refresh_token(user_id=1, username='alice')
+        assert _count_active_tokens(1) == 1
+
+        assert revoke_refresh_token(token, user_id=1) is True
+        assert _count_active_tokens(1) == 0
+
+    def test_does_not_revoke_when_user_id_mismatches(self, app):
+        """Bug #1: /logout previously let any user revoke any refresh token."""
+        from server.utils.auth_utils import revoke_refresh_token
+
+        token = _make_refresh_token(user_id=1, username='alice')
+        assert _count_active_tokens(1) == 1
+
+        # User 2 tries to revoke user 1's token.
+        result = revoke_refresh_token(token, user_id=2)
+
+        assert result is False, "revoke must not succeed across users"
+        assert _count_active_tokens(1) == 1, "victim's token must stay active"
+
+    def test_backwards_compatible_without_user_id(self, app):
+        """Callers that omit user_id (legacy callers) still work."""
+        from server.utils.auth_utils import revoke_refresh_token
+
+        token = _make_refresh_token(user_id=1, username='alice')
+        assert revoke_refresh_token(token) is True
+        assert _count_active_tokens(1) == 0
+
+    def test_missing_token_returns_false(self, app):
+        from server.utils.auth_utils import revoke_refresh_token
+        assert revoke_refresh_token('not-a-real-token', user_id=1) is False
+
+
+class TestRevokeAllUserRefreshTokens:
+    """revoke_all_user_refresh_tokens is what /change-password relies on."""
+
+    def test_revokes_every_active_token_for_user(self, app):
+        from server.utils.auth_utils import revoke_all_user_refresh_tokens
+
+        _make_refresh_token(user_id=1, username='alice')
+        _make_refresh_token(user_id=1, username='alice')
+        _make_refresh_token(user_id=1, username='alice')
+        assert _count_active_tokens(1) == 3
+
+        count = revoke_all_user_refresh_tokens(1)
+
+        assert count == 3
+        assert _count_active_tokens(1) == 0
+
+    def test_does_not_touch_other_users_tokens(self, app):
+        """Bug #2: changing user 1's password must NOT affect user 2."""
+        from server.utils.auth_utils import revoke_all_user_refresh_tokens
+
+        _make_refresh_token(user_id=1, username='alice')
+        _make_refresh_token(user_id=2, username='bob')
+        _make_refresh_token(user_id=2, username='bob')
+
+        revoke_all_user_refresh_tokens(1)
+
+        assert _count_active_tokens(1) == 0
+        assert _count_active_tokens(2) == 2, "other users' sessions must remain"
+
+    def test_is_idempotent(self, app):
+        """Calling twice in a row is safe and reports zero the second time."""
+        from server.utils.auth_utils import revoke_all_user_refresh_tokens
+
+        _make_refresh_token(user_id=1, username='alice')
+
+        first = revoke_all_user_refresh_tokens(1)
+        second = revoke_all_user_refresh_tokens(1)
+
+        assert first == 1
+        assert second == 0
+
+    def test_skips_already_revoked_tokens(self, app):
+        from server.utils.auth_utils import (
+            revoke_all_user_refresh_tokens,
+            revoke_refresh_token,
+        )
+
+        t1 = _make_refresh_token(user_id=1, username='alice')
+        _make_refresh_token(user_id=1, username='alice')
+        revoke_refresh_token(t1, user_id=1)  # pre-revoke one
+
+        count = revoke_all_user_refresh_tokens(1)
+
+        # Only the remaining active token is newly revoked.
+        assert count == 1
+        assert _count_active_tokens(1) == 0
+
+    def test_returns_zero_when_user_has_no_tokens(self, app):
+        from server.utils.auth_utils import revoke_all_user_refresh_tokens
+        assert revoke_all_user_refresh_tokens(999) == 0

--- a/server/utils/auth_utils.py
+++ b/server/utils/auth_utils.py
@@ -119,11 +119,39 @@ def token_required(f):
     return decorated
 
 
-def revoke_refresh_token(token):
-    """Revoke a refresh token"""
-    refresh_token = RefreshToken.query.filter_by(token=token).first()
+def revoke_refresh_token(token, user_id=None):
+    """Revoke a refresh token.
+
+    When ``user_id`` is provided, the token is only revoked when it belongs to
+    that user. This prevents a user with a valid access token from revoking
+    refresh tokens belonging to a different user (e.g. causing a denial of
+    service if a token string is leaked).
+
+    Returns True if a matching token was revoked, False otherwise.
+    """
+    query = RefreshToken.query.filter_by(token=token)
+    if user_id is not None:
+        query = query.filter_by(user_id=user_id)
+    refresh_token = query.first()
     if refresh_token:
         refresh_token.is_revoked = True
         db.session.commit()
         return True
     return False
+
+
+def revoke_all_user_refresh_tokens(user_id):
+    """Revoke every active refresh token for the given user.
+
+    Intended to be called after security-sensitive events (password change,
+    account takeover suspicion, admin action) so that previously-issued
+    refresh tokens can no longer be exchanged for new access tokens.
+
+    Returns the number of tokens that were revoked.
+    """
+    count = RefreshToken.query.filter_by(
+        user_id=user_id,
+        is_revoked=False,
+    ).update({'is_revoked': True})
+    db.session.commit()
+    return count


### PR DESCRIPTION
## Summary

Fixes two genuine security bugs in the JWT auth flow merged in PR #72. Both bugs are in already-merged code and no open PR is addressing them.

## Bug 1 — `/logout` lets any user revoke any refresh token

[revoke_refresh_token(token)](cci:1://file:///e:/stellar_journey/opensource/calliope_ide/server/utils/auth_utils.py:121:0-139:16) looked up the row by token string only, with no ownership check. An attacker with a valid account who obtains a victim's refresh token (log leak, DB dump, shared device, token pasted in a support ticket, etc.) can call `/logout` with the victim's token and force them to be logged out — a targeted denial of service.

**Fix**: [revoke_refresh_token](cci:1://file:///e:/stellar_journey/opensource/calliope_ide/server/utils/auth_utils.py:121:0-139:16) now accepts an optional `user_id` argument and `/logout` passes `user_id=current_user.id`, so the DB query is scoped to the authenticated caller. The signature is backwards compatible — callers that omit `user_id` still behave as before.

## Bug 2 — `/change-password` leaves previously-issued sessions valid

After a user changes their password, all previously-issued refresh tokens remain valid, so an attacker who had already stolen a refresh token can continue to mint new access tokens even after the legitimate owner rotates their password. This contradicts the entire point of changing a password after a suspected compromise, and is how industry-standard flows behave (Google, GitHub, Auth0 all invalidate sessions on password change).

**Fix**: Added [revoke_all_user_refresh_tokens(user_id)](cci:1://file:///e:/stellar_journey/opensource/calliope_ide/server/utils/auth_utils.py:142:0-156:16) in [server/utils/auth_utils.py](cci:7://file:///e:/stellar_journey/opensource/calliope_ide/server/utils/auth_utils.py:0:0-0:0) which bulk-updates every non-revoked [RefreshToken](cci:2://file:///e:/stellar_journey/opensource/calliope_ide/server/models/refresh_token.py:5:0-19:66) row for a user to `is_revoked=True`. `/change-password` calls it after committing the new password hash and returns the number of revoked sessions in the response so the UI can tell the user to log back in on their other devices.

## Files changed

- [server/utils/auth_utils.py](cci:7://file:///e:/stellar_journey/opensource/calliope_ide/server/utils/auth_utils.py:0:0-0:0) — [revoke_refresh_token](cci:1://file:///e:/stellar_journey/opensource/calliope_ide/server/utils/auth_utils.py:121:0-139:16) gets optional `user_id`, plus a new [revoke_all_user_refresh_tokens](cci:1://file:///e:/stellar_journey/opensource/calliope_ide/server/utils/auth_utils.py:142:0-156:16) helper.
- [server/routes/auth_routes.py](cci:7://file:///e:/stellar_journey/opensource/calliope_ide/server/routes/auth_routes.py:0:0-0:0) — `/logout` scopes to caller, `/change-password` invalidates sessions.
- [server/tests/test_refresh_token_revocation.py](cci:7://file:///e:/stellar_journey/opensource/calliope_ide/server/tests/test_refresh_token_revocation.py:0:0-0:0) — 9 new regression tests.

## Tests
