### PR TITLE
feat(editor): add file explorer and workspace tree

### DIFF
--- a/components/FileExplorer.jsx
+++ b/components/FileExplorer.jsx
@@ -1,0 +1,224 @@
+import React, { useState, useEffect, useCallback } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import { 
+    Folder, 
+    FolderOpen, 
+    File, 
+    ChevronRight, 
+    ChevronDown, 
+    RefreshCw,
+    FileText,
+    Settings,
+    Code,
+    Terminal
+} from "lucide-react"
+import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:5000"
+
+function cn(...inputs) {
+    return twMerge(clsx(inputs))
+}
+
+const FileIcon = ({ fileName, isDir }) => {
+    if (isDir) return null; // Handled by folder component
+    
+    const ext = fileName.split('.').pop().toLowerCase();
+    
+    switch (ext) {
+        case 'rs':
+            return <Code className="w-4 h-4 text-orange-400" />;
+        case 'py':
+            return <Code className="w-4 h-4 text-blue-400" />;
+        case 'js':
+        case 'jsx':
+            return <Code className="w-4 h-4 text-yellow-400" />;
+        case 'ts':
+        case 'tsx':
+            return <Code className="w-4 h-4 text-blue-500" />;
+        case 'json':
+            return <FileText className="w-4 h-4 text-yellow-300" />;
+        case 'toml':
+            return <Settings className="w-4 h-4 text-gray-400" />;
+        case 'md':
+            return <FileText className="w-4 h-4 text-blue-300" />;
+        case 'sh':
+            return <Terminal className="w-4 h-4 text-green-400" />;
+        default:
+            return <File className="w-4 h-4 text-gray-400" />;
+    }
+};
+
+const TreeItem = ({ item, level = 0, onFileSelect, activeFile }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const isSelected = activeFile === item.path;
+
+    const toggleOpen = (e) => {
+        e.stopPropagation();
+        if (item.is_dir) {
+            setIsOpen(!isOpen);
+        }
+    };
+
+    const handleClick = () => {
+        if (item.is_dir) {
+            setIsOpen(!isOpen);
+        } else {
+            onFileSelect(item.path);
+        }
+    };
+
+    return (
+        <div className="select-none">
+            <div
+                onClick={handleClick}
+                className={cn(
+                    "flex items-center gap-1 px-2 py-1 rounded cursor-pointer transition-colors group",
+                    isSelected ? "bg-gray-700 text-white" : "text-gray-400 hover:bg-gray-800 hover:text-gray-200"
+                )}
+                style={{ paddingLeft: `${level * 12 + 8}px` }}
+            >
+                {item.is_dir ? (
+                    <div className="flex items-center gap-1 w-full overflow-hidden">
+                        <span className="shrink-0">
+                            {isOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+                        </span>
+                        <span className="shrink-0 text-blue-400">
+                            {isOpen ? <FolderOpen className="w-4 h-4" /> : <Folder className="w-4 h-4" />}
+                        </span>
+                        <span className="text-sm truncate font-medium">{item.name}</span>
+                    </div>
+                ) : (
+                    <div className="flex items-center gap-2 w-full overflow-hidden">
+                        <span className="w-4 shrink-0" /> {/* Spacer for chevron */}
+                        <span className="shrink-0">
+                            <FileIcon fileName={item.name} isDir={false} />
+                        </span>
+                        <span className={cn(
+                            "text-sm truncate",
+                            isSelected ? "font-semibold" : ""
+                        )}>{item.name}</span>
+                    </div>
+                )}
+            </div>
+
+            <AnimatePresence>
+                {item.is_dir && isOpen && item.children && (
+                    <motion.div
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: "auto", opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{ duration: 0.2, ease: "easeInOut" }}
+                        className="overflow-hidden"
+                    >
+                        {item.children.map((child) => (
+                            <TreeItem
+                                key={child.path}
+                                item={child}
+                                level={level + 1}
+                                onFileSelect={onFileSelect}
+                                activeFile={activeFile}
+                            />
+                        ))}
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+};
+
+export default function FileExplorer({ projectId, onFileSelect, activeFile }) {
+    const [tree, setTree] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    const fetchTree = useCallback(async () => {
+        if (!projectId) return;
+        
+        setLoading(true);
+        setError(null);
+        
+        const token = localStorage.getItem("access_token");
+        try {
+            const res = await fetch(`${BACKEND_URL}/api/projects/${projectId}/files/tree`, {
+                headers: { Authorization: `Bearer ${token}` }
+            });
+            const data = await res.json();
+            
+            if (data.success) {
+                setTree(data.tree);
+            } else {
+                setError(data.error || "Failed to load tree");
+            }
+        } catch (err) {
+            setError("Network error loading tree");
+        } finally {
+            setLoading(false);
+        }
+    }, [projectId]);
+
+    useEffect(() => {
+        fetchTree();
+    }, [fetchTree]);
+
+    if (!projectId) {
+        return (
+            <div className="p-4 text-center text-gray-500 text-sm italic">
+                No project workspace loaded.
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col h-full">
+            <div className="flex items-center justify-between px-4 py-2 bg-[#161B22] border-b border-gray-700/50 sticky top-0 z-10">
+                <span className="text-[10px] uppercase tracking-wider font-bold text-gray-500">Workspace</span>
+                <button 
+                    onClick={fetchTree}
+                    disabled={loading}
+                    className="p-1 hover:bg-gray-700 rounded transition-colors disabled:opacity-50"
+                    title="Refresh Explorer"
+                >
+                    <RefreshCw className={cn("w-3 h-3 text-gray-400", loading && "animate-spin")} />
+                </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto custom-scrollbar p-1">
+                {loading && !tree ? (
+                    <div className="flex flex-col items-center justify-center h-20 gap-2">
+                        <div className="w-4 h-4 border-2 border-gray-600 border-t-blue-500 rounded-full animate-spin" />
+                        <span className="text-xs text-gray-500">Loading structure...</span>
+                    </div>
+                ) : error ? (
+                    <div className="p-4 text-center">
+                        <p className="text-xs text-red-400 mb-2">{error}</p>
+                        <button 
+                            onClick={fetchTree}
+                            className="text-[10px] px-2 py-1 bg-gray-800 hover:bg-gray-700 rounded text-gray-300 transition-colors"
+                        >
+                            Retry
+                        </button>
+                    </div>
+                ) : tree ? (
+                    <div className="py-1">
+                        {tree.children && tree.children.length > 0 ? (
+                            tree.children.map((item) => (
+                                <TreeItem
+                                    key={item.path}
+                                    item={item}
+                                    onFileSelect={onFileSelect}
+                                    activeFile={activeFile}
+                                />
+                            ))
+                        ) : (
+                            <div className="p-4 text-center text-xs text-gray-500 italic">
+                                Project directory is empty.
+                            </div>
+                        )}
+                    </div>
+                ) : null}
+            </div>
+        </div>
+    );
+}

--- a/pages/app/index.jsx
+++ b/pages/app/index.jsx
@@ -26,6 +26,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { getPublicKey, signTransaction, isConnected } from "@stellar/freighter-api"
 import ContractInteraction from "@/components/ContractInteraction"
+import FileExplorer from "@/components/FileExplorer"
 
 // ── Config ─────────────────────────────────────────────────────────────────────
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:5000"
@@ -758,30 +759,13 @@ export default function IDEApp() {
                             </Button>
                         </div>
 
-                        <div className="flex-1 overflow-y-auto">
+                        <div className="flex-1 overflow-y-auto overflow-x-hidden">
                             {sidebarTab === "explorer" && (
-                                <div className="p-3 space-y-0.5">
-                                    {[
-                                        { icon: <FolderOpen className="w-4 h-4 text-blue-400 shrink-0" />, label: "src/",        indent: false, path: null },
-                                        { icon: <span className="w-4 text-center text-xs shrink-0">📄</span>, label: "contract.rs", indent: true,  path: "./workspace/src/contract.rs" },
-                                        { icon: <span className="w-4 text-center text-xs shrink-0">📄</span>, label: "lib.rs",      indent: true,  path: "./workspace/src/lib.rs" },
-                                        { icon: <FolderOpen className="w-4 h-4 text-blue-400 shrink-0" />, label: "tests/",      indent: false, path: null },
-                                        { icon: <span className="w-4 text-center text-xs shrink-0">📄</span>, label: "Cargo.toml", indent: false, path: "./workspace/Cargo.toml" },
-                                    ].map(({ icon, label, indent, path }) => (
-                                        <div
-                                            key={label}
-                                            onClick={() => path && handleFileSelect(path)}
-                                            className={[
-                                                "flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-700 cursor-pointer transition-colors",
-                                                indent ? "ml-4" : "",
-                                                activeFile === path && path ? "bg-gray-700 border-l-2 border-blue-400" : "",
-                                            ].join(" ")}
-                                        >
-                                            {icon}
-                                            <span className="text-sm truncate">{label}</span>
-                                        </div>
-                                    ))}
-                                </div>
+                                <FileExplorer 
+                                    projectId={projectId}
+                                    onFileSelect={handleFileSelect}
+                                    activeFile={activeFile}
+                                />
                             )}
 
                             {sidebarTab === "contract" && (

--- a/server/routes/project_routes.py
+++ b/server/routes/project_routes.py
@@ -500,7 +500,96 @@ def read_project_file(current_user, project_id):
         return jsonify({'success': False, 'error': 'An error occurred while reading the file'}), 500
 
 
+@project_bp.route('/<int:project_id>/files/tree', methods=['GET'])
+@token_required
+def get_project_tree(current_user, project_id):
+    """
+    Get the directory tree structure of the project.
+    """
+    try:
+        project = ProjectMetadata.query.filter_by(
+            id=project_id, user_id=current_user.id, is_active=True
+        ).first()
+
+        if not project:
+            return jsonify({'success': False, 'error': 'Project not found'}), 404
+
+        if not project.project_path:
+            return jsonify({'success': False, 'error': 'Project has no path configured'}), 400
+
+        import os
+        abs_project = os.path.realpath(project.project_path)
+        
+        if not os.path.exists(abs_project):
+            return jsonify({'success': False, 'error': 'Project directory does not exist on disk'}), 404
+
+        tree = _get_directory_tree(abs_project, abs_project)
+
+        return jsonify({
+            'success': True,
+            'tree': tree
+        }), 200
+
+    except Exception as e:
+        logger.exception("Get project tree error")
+        capture_exception(e, {
+            'route': 'project.get_project_tree',
+            'user_id': current_user.id,
+            'project_id': project_id,
+        })
+        return jsonify({'success': False, 'error': 'An error occurred while building the file tree'}), 500
+
+
 # ── Helper ────────────────────────────────────────────────────────────────────
+
+def _get_directory_tree(path: str, base_path: str) -> dict:
+    """
+    Recursively build a directory tree.
+    """
+    import os
+    
+    # Same skip list as context_builder.py
+    skip_dirs = {"node_modules", ".git", "target", "__pycache__", ".next",
+                 "dist", "build", ".venv", "venv"}
+    
+    name = os.path.basename(path)
+    if not name and path == base_path:
+        name = os.path.basename(os.path.normpath(path))
+    
+    relative_path = os.path.relpath(path, base_path)
+    if relative_path == ".":
+        relative_path = ""
+
+    item = {
+        "name": name,
+        "path": path,
+        "relative_path": relative_path,
+        "is_dir": os.path.isdir(path)
+    }
+
+    if item["is_dir"]:
+        children = []
+        try:
+            # Sort: directories first, then alphabetically
+            entries = os.listdir(path)
+            entries.sort(key=lambda x: (not os.path.isdir(os.path.join(path, x)), x.lower()))
+            
+            for entry in entries:
+                if entry in skip_dirs:
+                    continue
+                
+                # Optionally skip hidden files (except common ones)
+                if entry.startswith(".") and entry not in (".env", ".gitignore", ".eslintrc.json"):
+                    continue
+                    
+                child_path = os.path.join(path, entry)
+                children.append(_get_directory_tree(child_path, base_path))
+        except OSError:
+            pass
+        item["children"] = children
+    
+    return item
+
 
 def _relative_path(absolute: str, base: str) -> str:
     import os


### PR DESCRIPTION
This PR implements a dynamic sidebar file explorer for CalliopeIDE to replace the previous hardcoded lists.

### Changes:
- **Backend**: Added a new endpoint `GET /api/projects/<id>/files/tree` that recursively scans the project directory and returns a JSON tree structure.
- **Frontend Component**: Created `FileExplorer.jsx`, a recursive tree view component using Framer Motion for smooth animations.
- **Integration**: Replaced the hardcoded explorer in `pages/app/index.jsx` with the new dynamic component.
- **Polishing**: Added file-type specific icons (Rust, Python, JS, etc.) and automatic sorting (directories first).

Fixes #52