### PR TITLE
feat: dynamic file explorer & workspace tree sidebar (fixes #52)

### DIFF
--- a/components/FileExplorer.jsx
+++ b/components/FileExplorer.jsx
@@ -1,0 +1,295 @@
+/**
+ * FileExplorer — resolves issue #52
+ *
+ * A dynamic sidebar tree that:
+ *   - Fetches the real workspace structure from GET /api/projects/:id/files/tree
+ *   - Supports expand/collapse of folders
+ *   - Opens files in the Monaco editor via onFileSelect callback
+ *   - Reflects real workspace state (re-fetches when `refreshKey` changes)
+ *   - Shows loading skeleton and error states
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import {
+    ChevronRight,
+    ChevronDown,
+    FolderOpen,
+    Folder,
+    FileCode,
+    FileText,
+    RefreshCw,
+    AlertCircle,
+} from "lucide-react"
+
+// ── File-type icon map ────────────────────────────────────────────────────────
+const EXT_ICONS = {
+    ".rs":    <FileCode  className="w-3.5 h-3.5 text-orange-400 shrink-0" />,
+    ".ts":    <FileCode  className="w-3.5 h-3.5 text-blue-400   shrink-0" />,
+    ".tsx":   <FileCode  className="w-3.5 h-3.5 text-blue-400   shrink-0" />,
+    ".js":    <FileCode  className="w-3.5 h-3.5 text-yellow-400 shrink-0" />,
+    ".jsx":   <FileCode  className="w-3.5 h-3.5 text-yellow-400 shrink-0" />,
+    ".py":    <FileCode  className="w-3.5 h-3.5 text-green-400  shrink-0" />,
+    ".toml":  <FileText  className="w-3.5 h-3.5 text-gray-400   shrink-0" />,
+    ".json":  <FileText  className="w-3.5 h-3.5 text-yellow-300 shrink-0" />,
+    ".md":    <FileText  className="w-3.5 h-3.5 text-gray-300   shrink-0" />,
+    ".yml":   <FileText  className="w-3.5 h-3.5 text-red-400    shrink-0" />,
+    ".yaml":  <FileText  className="w-3.5 h-3.5 text-red-400    shrink-0" />,
+    ".css":   <FileCode  className="w-3.5 h-3.5 text-pink-400   shrink-0" />,
+    ".html":  <FileCode  className="w-3.5 h-3.5 text-orange-300 shrink-0" />,
+}
+
+function fileIcon(extension) {
+    return EXT_ICONS[extension] || (
+        <FileText className="w-3.5 h-3.5 text-gray-500 shrink-0" />
+    )
+}
+
+// ── Single tree node ──────────────────────────────────────────────────────────
+function TreeNode({ node, depth, activeFile, onFileSelect }) {
+    const [open, setOpen] = useState(depth < 1)   // top-level folders open by default
+
+    const isDir  = node.type === "directory"
+    const isFile = node.type === "file"
+    const isActive = isFile && activeFile === node.path
+
+    const indent = depth * 12  // px per level
+
+    const handleClick = () => {
+        if (isDir)  setOpen((v) => !v)
+        if (isFile) onFileSelect(node.path)
+    }
+
+    return (
+        <div>
+            {/* Row */}
+            <div
+                role={isFile ? "button" : "treeitem"}
+                aria-expanded={isDir ? open : undefined}
+                aria-selected={isActive}
+                tabIndex={0}
+                onClick={handleClick}
+                onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && handleClick()}
+                style={{ paddingLeft: `${indent + 8}px` }}
+                className={[
+                    "flex items-center gap-1.5 py-[3px] pr-2 rounded cursor-pointer select-none",
+                    "text-sm transition-colors duration-100",
+                    isActive
+                        ? "bg-blue-900/60 text-white border-l-2 border-blue-400"
+                        : "text-gray-300 hover:bg-gray-700/60 hover:text-white",
+                ].join(" ")}
+            >
+                {/* Folder chevron / file placeholder */}
+                <span className="w-3.5 shrink-0 flex items-center justify-center">
+                    {isDir
+                        ? (open
+                            ? <ChevronDown  className="w-3 h-3 text-gray-400" />
+                            : <ChevronRight className="w-3 h-3 text-gray-400" />)
+                        : null
+                    }
+                </span>
+
+                {/* Icon */}
+                {isDir
+                    ? (open
+                        ? <FolderOpen className="w-3.5 h-3.5 text-blue-400 shrink-0" />
+                        : <Folder     className="w-3.5 h-3.5 text-blue-400 shrink-0" />)
+                    : fileIcon(node.extension || "")
+                }
+
+                {/* Name */}
+                <span className="truncate">{node.name}</span>
+            </div>
+
+            {/* Children */}
+            {isDir && (
+                <AnimatePresence initial={false}>
+                    {open && node.children && node.children.length > 0 && (
+                        <motion.div
+                            key="children"
+                            initial={{ height: 0, opacity: 0 }}
+                            animate={{ height: "auto", opacity: 1 }}
+                            exit={{ height: 0, opacity: 0 }}
+                            transition={{ duration: 0.15, ease: "easeInOut" }}
+                            style={{ overflow: "hidden" }}
+                        >
+                            {node.children.map((child) => (
+                                <TreeNode
+                                    key={child.path}
+                                    node={child}
+                                    depth={depth + 1}
+                                    activeFile={activeFile}
+                                    onFileSelect={onFileSelect}
+                                />
+                            ))}
+                        </motion.div>
+                    )}
+                    {open && isDir && node.children && node.children.length === 0 && (
+                        <p
+                            style={{ paddingLeft: `${(depth + 1) * 12 + 8 + 14}px` }}
+                            className="py-1 text-xs text-gray-600 italic"
+                        >
+                            empty
+                        </p>
+                    )}
+                </AnimatePresence>
+            )}
+        </div>
+    )
+}
+
+// ── Loading skeleton ──────────────────────────────────────────────────────────
+function TreeSkeleton() {
+    const rows = [
+        { w: "60%", indent: 8 },
+        { w: "45%", indent: 22 },
+        { w: "50%", indent: 22 },
+        { w: "55%", indent: 8 },
+        { w: "40%", indent: 22 },
+        { w: "65%", indent: 8 },
+    ]
+    return (
+        <div className="p-2 space-y-1 animate-pulse">
+            {rows.map(({ w, indent }, i) => (
+                <div
+                    key={i}
+                    style={{ paddingLeft: indent, width: w }}
+                    className="h-4 bg-gray-700/60 rounded"
+                />
+            ))}
+        </div>
+    )
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+/**
+ * @param {{ projectId: number|null, token: string|null, backendUrl: string,
+ *           activeFile: string|null, onFileSelect: (path:string)=>void,
+ *           refreshKey: number }} props
+ */
+export default function FileExplorer({
+    projectId,
+    token,
+    backendUrl,
+    activeFile,
+    onFileSelect,
+    refreshKey = 0,
+}) {
+    const [tree,    setTree]    = useState([])
+    const [loading, setLoading] = useState(false)
+    const [error,   setError]   = useState(null)
+    const abortRef = useRef(null)
+
+    const fetchTree = useCallback(async () => {
+        if (!projectId || !token) {
+            setTree([])
+            return
+        }
+
+        // Cancel any in-flight request
+        abortRef.current?.abort()
+        abortRef.current = new AbortController()
+
+        setLoading(true)
+        setError(null)
+
+        try {
+            const res = await fetch(
+                `${backendUrl}/api/projects/${projectId}/files/tree`,
+                {
+                    headers: { Authorization: `Bearer ${token}` },
+                    signal: abortRef.current.signal,
+                }
+            )
+
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}))
+                throw new Error(data.error || `HTTP ${res.status}`)
+            }
+
+            const data = await res.json()
+            if (data.success) {
+                setTree(data.tree || [])
+            } else {
+                throw new Error(data.error || "Unknown error")
+            }
+        } catch (err) {
+            if (err.name === "AbortError") return  // component unmounted / re-fetching
+            setError(err.message)
+        } finally {
+            setLoading(false)
+        }
+    }, [projectId, token, backendUrl])
+
+    // Re-fetch whenever projectId, token, or refreshKey changes
+    useEffect(() => {
+        fetchTree()
+        return () => abortRef.current?.abort()
+    }, [fetchTree, refreshKey])
+
+    // ── Render ────────────────────────────────────────────────────────────────
+    return (
+        <div className="flex flex-col h-full min-h-0">
+            {/* Header row */}
+            <div className="flex items-center justify-between px-3 py-1.5 border-b border-gray-700/50">
+                <span className="text-[10px] font-semibold uppercase tracking-widest text-gray-500">
+                    Explorer
+                </span>
+                <button
+                    onClick={fetchTree}
+                    title="Refresh file tree"
+                    aria-label="Refresh file tree"
+                    className="p-0.5 rounded text-gray-500 hover:text-gray-300 transition-colors"
+                >
+                    <RefreshCw
+                        className={`w-3 h-3 ${loading ? "animate-spin" : ""}`}
+                    />
+                </button>
+            </div>
+
+            {/* Body */}
+            <div
+                role="tree"
+                aria-label="Project file tree"
+                className="flex-1 overflow-y-auto py-1 text-sm"
+            >
+                {loading && tree.length === 0 && <TreeSkeleton />}
+
+                {!loading && error && (
+                    <div className="flex flex-col items-center gap-2 p-4 text-center">
+                        <AlertCircle className="w-5 h-5 text-red-400" />
+                        <p className="text-xs text-gray-400">{error}</p>
+                        <button
+                            onClick={fetchTree}
+                            className="text-xs text-blue-400 hover:underline"
+                        >
+                            Retry
+                        </button>
+                    </div>
+                )}
+
+                {!loading && !error && tree.length === 0 && projectId && (
+                    <p className="px-4 py-3 text-xs text-gray-500 italic">
+                        No files found in workspace.
+                    </p>
+                )}
+
+                {!projectId && (
+                    <p className="px-4 py-3 text-xs text-gray-500 italic">
+                        No project loaded.
+                    </p>
+                )}
+
+                {tree.map((node) => (
+                    <TreeNode
+                        key={node.path}
+                        node={node}
+                        depth={0}
+                        activeFile={activeFile}
+                        onFileSelect={onFileSelect}
+                    />
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/pages/app/index.jsx
+++ b/pages/app/index.jsx
@@ -27,6 +27,7 @@ import { Button } from "@/components/ui/button"
 import { getPublicKey, signTransaction, isConnected } from "@stellar/freighter-api"
 import ContractInteraction from "@/components/ContractInteraction"
 import MonacoEditor from "@/components/MonacoEditor"
+import FileExplorer from "@/components/FileExplorer"
 
 // ── Config ─────────────────────────────────────────────────────────────────────
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:5000"
@@ -140,6 +141,9 @@ export default function IDEApp() {
     const [projectId, setProjectId]   = useState(null)  // from auth session
     const [fileContent, setFileContent] = useState(CODE_LINES.map(l => l.code).join("\n"))
     const [saveStatus, setSaveStatus] = useState("idle") // "idle" | "saving" | "saved" | "error"
+
+    // Bump this to force FileExplorer to re-fetch the tree (issue #52)
+    const [fileTreeRefreshKey, setFileTreeRefreshKey] = useState(0)
 
     // Monaco multi-file editor state (Issue #51)
     const [openFiles, setOpenFiles] = useState([
@@ -478,6 +482,7 @@ export default function IDEApp() {
                     const data = await res.json()
                     if (data.success) {
                         setSaveStatus("saved")
+                        setFileTreeRefreshKey((k) => k + 1)  // refresh explorer tree (issue #52)
                         handleSave()
                     } else {
                         setSaveStatus("error")
@@ -833,28 +838,14 @@ export default function IDEApp() {
 
                         <div className="flex-1 overflow-y-auto">
                             {sidebarTab === "explorer" && (
-                                <div className="p-3 space-y-0.5">
-                                    {[
-                                        { icon: <FolderOpen className="w-4 h-4 text-blue-400 shrink-0" />, label: "src/",        indent: false, path: null },
-                                        { icon: <span className="w-4 text-center text-xs shrink-0">📄</span>, label: "contract.rs", indent: true,  path: "./workspace/src/contract.rs" },
-                                        { icon: <span className="w-4 text-center text-xs shrink-0">📄</span>, label: "lib.rs",      indent: true,  path: "./workspace/src/lib.rs" },
-                                        { icon: <FolderOpen className="w-4 h-4 text-blue-400 shrink-0" />, label: "tests/",      indent: false, path: null },
-                                        { icon: <span className="w-4 text-center text-xs shrink-0">📄</span>, label: "Cargo.toml", indent: false, path: "./workspace/Cargo.toml" },
-                                    ].map(({ icon, label, indent, path }) => (
-                                        <div
-                                            key={label}
-                                            onClick={() => path && handleFileSelect(path)}
-                                            className={[
-                                                "flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-700 cursor-pointer transition-colors",
-                                                indent ? "ml-4" : "",
-                                                activeFile === path && path ? "bg-gray-700 border-l-2 border-blue-400" : "",
-                                            ].join(" ")}
-                                        >
-                                            {icon}
-                                            <span className="text-sm truncate">{label}</span>
-                                        </div>
-                                    ))}
-                                </div>
+                                <FileExplorer
+                                    projectId={projectId}
+                                    token={getAuthToken()}
+                                    backendUrl={BACKEND_URL}
+                                    activeFile={activeFile}
+                                    onFileSelect={handleFileSelect}
+                                    refreshKey={fileTreeRefreshKey}
+                                />
                             )}
 
                             {sidebarTab === "contract" && (

--- a/server/routes/project_routes.py
+++ b/server/routes/project_routes.py
@@ -500,6 +500,147 @@ def read_project_file(current_user, project_id):
         return jsonify({'success': False, 'error': 'An error occurred while reading the file'}), 500
 
 
+@project_bp.route('/<int:project_id>/files/tree', methods=['GET'])
+@token_required
+def get_project_file_tree(current_user, project_id):
+    """
+    Return a recursive file-system tree for the project workspace.
+
+    Query parameters:
+        path  (optional) – subdirectory relative to project_path to list.
+                           Defaults to the project root.
+
+    Response:
+    {
+        "success": true,
+        "tree": [
+            {
+                "name": "src",
+                "path": "/abs/path/src",
+                "relative_path": "src",
+                "type": "directory",
+                "children": [
+                    {
+                        "name": "lib.rs",
+                        "path": "/abs/path/src/lib.rs",
+                        "relative_path": "src/lib.rs",
+                        "type": "file",
+                        "extension": ".rs",
+                        "size": 1024
+                    }
+                ]
+            }
+        ]
+    }
+    """
+    import os
+
+    # Directories / files to skip (common noise)
+    IGNORED_NAMES = {
+        '.git', '.svn', '__pycache__', 'node_modules', '.next',
+        '.venv', 'venv', '.env', 'dist', 'build', '.pytest_cache',
+        '.mypy_cache', '.tox', 'target', '.DS_Store', '.swc',
+        'coverage', '.coverage', 'htmlcov', '.idea', '.vscode',
+    }
+    IGNORED_EXTENSIONS = {'.pyc', '.pyo', '.pyd', '.so', '.o', '.a'}
+    MAX_DEPTH = 6   # prevent runaway recursion on large trees
+    MAX_ENTRIES = 500  # safety cap on total nodes returned
+
+    try:
+        project = ProjectMetadata.query.filter_by(
+            id=project_id, user_id=current_user.id, is_active=True
+        ).first()
+
+        if not project:
+            return jsonify({'success': False, 'error': 'Project not found'}), 404
+
+        if not project.project_path:
+            return jsonify({'success': False, 'error': 'Project has no path configured'}), 400
+
+        abs_project = os.path.realpath(project.project_path)
+
+        # Optional sub-path
+        sub_path = request.args.get('path', '').strip().lstrip('/')
+        if sub_path:
+            target = os.path.realpath(os.path.join(abs_project, sub_path))
+            if not target.startswith(abs_project):
+                return jsonify({'success': False, 'error': 'Path is outside project directory'}), 400
+        else:
+            target = abs_project
+
+        if not os.path.isdir(target):
+            return jsonify({'success': False, 'error': 'Target path is not a directory'}), 400
+
+        counter = {'n': 0}
+
+        def build_tree(directory: str, depth: int) -> list:
+            if depth > MAX_DEPTH or counter['n'] >= MAX_ENTRIES:
+                return []
+
+            entries = []
+            try:
+                items = sorted(os.scandir(directory), key=lambda e: (not e.is_dir(), e.name.lower()))
+            except PermissionError:
+                return []
+
+            for item in items:
+                if item.name in IGNORED_NAMES:
+                    continue
+                _, ext = os.path.splitext(item.name)
+                if ext in IGNORED_EXTENSIONS:
+                    continue
+
+                counter['n'] += 1
+                if counter['n'] > MAX_ENTRIES:
+                    break
+
+                abs_item = os.path.realpath(item.path)
+                rel = os.path.relpath(abs_item, abs_project)
+
+                if item.is_dir(follow_symlinks=False):
+                    children = build_tree(abs_item, depth + 1)
+                    entries.append({
+                        'name': item.name,
+                        'path': abs_item,
+                        'relative_path': rel,
+                        'type': 'directory',
+                        'children': children,
+                    })
+                else:
+                    try:
+                        size = item.stat().st_size
+                    except OSError:
+                        size = 0
+                    entries.append({
+                        'name': item.name,
+                        'path': abs_item,
+                        'relative_path': rel,
+                        'type': 'file',
+                        'extension': ext.lower(),
+                        'size': size,
+                    })
+
+            return entries
+
+        tree = build_tree(target, depth=0)
+
+        return jsonify({
+            'success': True,
+            'project_path': abs_project,
+            'tree': tree,
+            'total_nodes': counter['n'],
+        }), 200
+
+    except Exception as e:
+        logger.exception("Get project file tree error")
+        capture_exception(e, {
+            'route': 'project.get_project_file_tree',
+            'user_id': current_user.id,
+            'project_id': project_id,
+        })
+        return jsonify({'success': False, 'error': 'An error occurred while building the file tree'}), 500
+
+
 # ── Helper ────────────────────────────────────────────────────────────────────
 
 def _relative_path(absolute: str, base: str) -> str:


### PR DESCRIPTION
## Summary
Closes #52 
Implements a fully dynamic file explorer sidebar that replaces the previous hardcoded static file list.

## Changes

### Backend (server/routes/project_routes.py)
- Added GET /api/projects/:id/files/tree endpoint
- - Recursively walks project directory using os.scandir
- - Sorts folders before files at every level
- - Skips noise dirs: node_modules, .git, __pycache__, target, .next, venv
- - Path-traversal security via os.path.realpath validation
- - Safety caps: MAX_DEPTH=6, MAX_ENTRIES=500
### Frontend (components/FileExplorer.jsx) - NEW FILE
- Fetches real workspace tree from backend (replaces hardcoded list)
- - Expand/collapse folders with smooth framer-motion animation
- - Per-extension colored file icons (.rs orange, .ts blue, .py green, .json yellow, etc.)
- - Active file highlighted with blue left-border
- - Loading skeleton on first fetch
- - Error state with Retry button
- - AbortController cancels stale requests
- - Re-fetches automatically when refreshKey prop changes
- - Full keyboard accessibility (Enter/Space to activate, aria roles)
### App Integration (pages/app/index.jsx)
- Imports FileExplorer
- - Adds fileTreeRefreshKey state - bumped on every successful autosave
- - Replaces 22 lines of hardcoded JSX with <FileExplorer> component
## Acceptance Criteria (from #52)
- [x] Users can browse project structure
- [ ] - [x] Files open correctly when clicked  
- [ ] - [x] Tree reflects real workspace state (fetched from filesystem via backend)
- [ ] - [x] UI updates dynamically (refreshKey bump on save triggers re-fetch)
## Testing
Tested locally with Flask backend + Next.js dev server. File tree loads correctly, expand/collapse works with animation, clicking files opens them in Monaco editor.