### PR TITLE
feat(soroban): add pre-flight simulation, contract event log, and fix dead blueprint registration

### DIFF
--- a/components/ContractEventLog.tsx
+++ b/components/ContractEventLog.tsx
@@ -1,0 +1,251 @@
+"use client"
+
+import { useState } from "react"
+import { Activity, RefreshCw, Filter, ChevronDown, ChevronUp, ExternalLink } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+interface SorobanEvent {
+  type: "CONTRACT" | "SYSTEM"
+  contract_id: string | null
+  topics: unknown[]
+  data: unknown
+  transaction_hash: string
+  timestamp: string
+  invoked_function: string
+}
+
+interface Props {
+  sessionId: number
+  authToken: string
+  apiBaseUrl?: string
+}
+
+function TopicBadge({ value }: { value: unknown }) {
+  const text = typeof value === "string" ? value : JSON.stringify(value)
+  return (
+    <span className="inline-block bg-blue-900/50 border border-blue-700 rounded px-1.5 py-0.5 font-mono text-[10px] text-blue-300">
+      {text}
+    </span>
+  )
+}
+
+function EventCard({ event, index }: { event: SorobanEvent; index: number }) {
+  const [open, setOpen] = useState(index === 0)
+
+  const typeColor =
+    event.type === "CONTRACT"
+      ? "text-purple-300 bg-purple-900/30 border-purple-700"
+      : "text-blue-300 bg-blue-900/30 border-blue-700"
+
+  const explorerUrl = event.transaction_hash
+    ? `https://stellar.expert/explorer/testnet/tx/${event.transaction_hash}`
+    : null
+
+  return (
+    <div className="border border-gray-700 rounded overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between px-3 py-2 bg-[#0D1117] hover:bg-gray-900 text-xs text-left"
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <span className={`shrink-0 text-[10px] px-1.5 py-0.5 rounded border font-semibold ${typeColor}`}>
+            {event.type}
+          </span>
+          <span className="font-mono text-gray-300 truncate">
+            {event.topics.length > 0 ? JSON.stringify(event.topics[0]) : "(no topics)"}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 shrink-0 ml-2">
+          <span className="text-gray-500 text-[10px]">
+            {event.timestamp ? event.timestamp.slice(0, 19).replace("T", " ") : ""}
+          </span>
+          {open ? <ChevronUp className="w-3 h-3 text-gray-500" /> : <ChevronDown className="w-3 h-3 text-gray-500" />}
+        </div>
+      </button>
+
+      {open && (
+        <div className="px-3 py-2 border-t border-gray-700 flex flex-col gap-2 text-xs bg-[#080C10]">
+          {event.contract_id && (
+            <div>
+              <span className="text-gray-500">Contract </span>
+              <span className="font-mono text-gray-300 break-all">{event.contract_id}</span>
+            </div>
+          )}
+
+          {event.invoked_function && (
+            <div>
+              <span className="text-gray-500">Via </span>
+              <span className="font-mono text-blue-300">{event.invoked_function}()</span>
+            </div>
+          )}
+
+          {event.topics.length > 0 && (
+            <div>
+              <p className="text-gray-500 mb-1">Topics</p>
+              <div className="flex flex-wrap gap-1">
+                {event.topics.map((t, i) => (
+                  <TopicBadge key={i} value={t} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {event.data !== null && event.data !== undefined && (
+            <div>
+              <p className="text-gray-500 mb-1">Data</p>
+              <pre className="font-mono text-[11px] text-gray-200 whitespace-pre-wrap break-all bg-[#0D1117] rounded p-2">
+                {JSON.stringify(event.data, null, 2)}
+              </pre>
+            </div>
+          )}
+
+          {explorerUrl && (
+            <a
+              href={explorerUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-blue-400 hover:text-blue-300 text-[10px] font-mono"
+            >
+              <ExternalLink className="w-3 h-3" />
+              {event.transaction_hash.slice(0, 16)}…
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function ContractEventLog({ sessionId, authToken, apiBaseUrl }: Props) {
+  const base = apiBaseUrl || process.env.NEXT_PUBLIC_API_URL || ""
+
+  const [events, setEvents] = useState<SorobanEvent[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [loaded, setLoaded] = useState(false)
+  const [filterContract, setFilterContract] = useState("")
+  const [filterActive, setFilterActive] = useState(false)
+
+  const headers = { Authorization: `Bearer ${authToken}` }
+
+  async function loadEvents(contractFilter?: string) {
+    setLoading(true)
+    setError(null)
+    try {
+      const qs = contractFilter ? `?contract_id=${encodeURIComponent(contractFilter)}` : ""
+      const res = await fetch(`${base}/api/soroban/events/${sessionId}${qs}`, { headers })
+      const data = await res.json()
+      if (!res.ok || !data.success) {
+        setError(data.error || "Failed to load events")
+      } else {
+        setEvents(data.events)
+        setLoaded(true)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Network error")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function handleRefresh() {
+    loadEvents(filterActive && filterContract ? filterContract : undefined)
+  }
+
+  function handleFilter(e: React.FormEvent) {
+    e.preventDefault()
+    const cf = filterContract.trim()
+    setFilterActive(!!cf)
+    loadEvents(cf || undefined)
+  }
+
+  function clearFilter() {
+    setFilterContract("")
+    setFilterActive(false)
+    loadEvents()
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4 text-sm text-white">
+      <div className="flex items-center justify-between">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400 flex items-center gap-1.5">
+          <Activity className="w-3 h-3 text-purple-400" />
+          Contract Events
+          {loaded && (
+            <span className="ml-1 text-[10px] text-gray-500 normal-case tracking-normal">
+              ({events.length})
+            </span>
+          )}
+        </h3>
+        <button
+          type="button"
+          onClick={handleRefresh}
+          disabled={loading}
+          className="text-gray-500 hover:text-white disabled:opacity-40"
+          title="Refresh"
+        >
+          <RefreshCw className={`w-3 h-3 ${loading ? "animate-spin" : ""}`} />
+        </button>
+      </div>
+
+      <form onSubmit={handleFilter} className="flex gap-2">
+        <input
+          className={`${inputCls} flex-1`}
+          placeholder="Filter by contract ID (optional)"
+          value={filterContract}
+          onChange={(e) => setFilterContract(e.target.value)}
+        />
+        <Button
+          type="submit"
+          disabled={loading}
+          className="bg-gray-700 hover:bg-gray-600 text-white text-xs px-2.5 py-1.5 shrink-0 flex items-center gap-1"
+        >
+          <Filter className="w-3 h-3" />
+          {filterActive ? "Refilter" : "Load"}
+        </Button>
+        {filterActive && (
+          <Button
+            type="button"
+            onClick={clearFilter}
+            className="bg-gray-800 hover:bg-gray-700 text-gray-300 text-xs px-2.5 py-1.5 shrink-0"
+          >
+            Clear
+          </Button>
+        )}
+      </form>
+
+      {error && (
+        <div className="p-2 bg-red-900/40 border border-red-700 rounded text-red-300 text-xs">
+          {error}
+        </div>
+      )}
+
+      {!loaded && !loading && (
+        <p className="text-gray-500 text-xs">
+          Load events to see contract activity from this session's invocations.
+        </p>
+      )}
+
+      {loaded && events.length === 0 && (
+        <p className="text-gray-500 text-xs">
+          {filterActive
+            ? "No events found for this contract."
+            : "No contract events recorded yet. Invoke a contract to see its events here."}
+        </p>
+      )}
+
+      {events.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {events.map((event, i) => (
+            <EventCard key={`${event.transaction_hash}-${i}`} event={event} index={i} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const inputCls =
+  "bg-[#0D1117] border border-gray-600 rounded px-2 py-1.5 text-xs text-white " +
+  "placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-purple-500 w-full"

--- a/components/SimulationPanel.tsx
+++ b/components/SimulationPanel.tsx
@@ -1,0 +1,362 @@
+"use client"
+
+import { useState } from "react"
+import { Zap, ChevronDown, ChevronUp, AlertTriangle, CheckCircle2, Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+type Network = "testnet" | "mainnet"
+
+interface FeeBreakdown {
+  base_fee: number
+  resource_fee: number
+  total_stroops: number
+  xlm: string
+}
+
+interface ResourceUsage {
+  cpu_insns: number
+  mem_bytes: number
+  read_bytes: number
+  write_bytes: number
+}
+
+interface SimulateInvokeResult {
+  success: boolean
+  fee: FeeBreakdown
+  resources: ResourceUsage
+  simulated_result: unknown
+  auth_entries: string[]
+  network: Network
+  simulation_error: string | null
+}
+
+interface SimulateDeployResult {
+  success: boolean
+  upload_fee: FeeBreakdown & { resources: ResourceUsage }
+  wasm_size_bytes: number
+  network: Network
+  note: string
+}
+
+interface Props {
+  sessionId: number
+  authToken: string
+  apiBaseUrl?: string
+  wasmPath?: string
+  mode?: "invoke" | "deploy"
+}
+
+function ResourceRow({ label, value, unit }: { label: string; value: number; unit: string }) {
+  return (
+    <div className="flex justify-between text-xs">
+      <span className="text-gray-400">{label}</span>
+      <span className="font-mono text-gray-200">
+        {value.toLocaleString()} {unit}
+      </span>
+    </div>
+  )
+}
+
+function FeeRow({ label, stroops, highlight }: { label: string; stroops: number; highlight?: boolean }) {
+  const xlm = (stroops / 10_000_000).toFixed(7)
+  return (
+    <div className={`flex justify-between text-xs ${highlight ? "font-semibold text-white" : "text-gray-300"}`}>
+      <span className={highlight ? "" : "text-gray-400"}>{label}</span>
+      <span className="font-mono">
+        {stroops.toLocaleString()} stroops
+        <span className="text-gray-500 ml-1">({xlm} XLM)</span>
+      </span>
+    </div>
+  )
+}
+
+export default function SimulationPanel({
+  sessionId,
+  authToken,
+  apiBaseUrl,
+  wasmPath,
+  mode = "invoke",
+}: Props) {
+  const base = apiBaseUrl || process.env.NEXT_PUBLIC_API_URL || ""
+
+  const [contractId, setContractId] = useState("")
+  const [functionName, setFunctionName] = useState("")
+  const [invokerPublicKey, setInvokerPublicKey] = useState("")
+  const [paramsRaw, setParamsRaw] = useState("")
+  const [network, setNetwork] = useState<Network>("testnet")
+
+  const [loading, setLoading] = useState(false)
+  const [invokeResult, setInvokeResult] = useState<SimulateInvokeResult | null>(null)
+  const [deployResult, setDeployResult] = useState<SimulateDeployResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [authOpen, setAuthOpen] = useState(false)
+
+  const headers = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${authToken}`,
+  }
+
+  async function handleSimulateInvoke(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setInvokeResult(null)
+    setError(null)
+
+    const parameters = paramsRaw
+      .split("\n")
+      .map((p) => p.trim())
+      .filter(Boolean)
+
+    try {
+      const res = await fetch(`${base}/api/soroban/simulate/invoke`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          session_id: sessionId,
+          contract_id: contractId.trim(),
+          function_name: functionName.trim(),
+          invoker_public_key: invokerPublicKey.trim(),
+          parameters,
+          network,
+        }),
+      })
+      const data: SimulateInvokeResult = await res.json()
+      if (!res.ok || !data.success) {
+        setError((data as { error?: string }).error || "Simulation failed")
+      } else {
+        setInvokeResult(data)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Network error")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleSimulateDeploy(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setDeployResult(null)
+    setError(null)
+
+    try {
+      const res = await fetch(`${base}/api/soroban/simulate/deploy`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          session_id: sessionId,
+          wasm_path: wasmPath,
+          deployer_public_key: invokerPublicKey.trim(),
+          network,
+        }),
+      })
+      const data: SimulateDeployResult = await res.json()
+      if (!res.ok || !data.success) {
+        setError((data as { error?: string }).error || "Simulation failed")
+      } else {
+        setDeployResult(data)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Network error")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const result = mode === "invoke" ? invokeResult : deployResult
+
+  return (
+    <div className="flex flex-col gap-4 p-4 text-sm text-white">
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400 flex items-center gap-1.5">
+        <Zap className="w-3 h-3 text-yellow-400" />
+        Pre-flight Simulation
+      </h3>
+
+      <form
+        onSubmit={mode === "invoke" ? handleSimulateInvoke : handleSimulateDeploy}
+        className="flex flex-col gap-2"
+      >
+        <select
+          className={`${inputCls} bg-[#0D1117]`}
+          value={network}
+          onChange={(e) => setNetwork(e.target.value as Network)}
+          disabled={loading}
+        >
+          <option value="testnet">Testnet</option>
+          <option value="mainnet">Mainnet</option>
+        </select>
+
+        {mode === "invoke" && (
+          <>
+            <input
+              className={inputCls}
+              placeholder="Contract ID (C...)"
+              value={contractId}
+              onChange={(e) => setContractId(e.target.value)}
+              disabled={loading}
+              required
+            />
+            <input
+              className={inputCls}
+              placeholder="Function name"
+              value={functionName}
+              onChange={(e) => setFunctionName(e.target.value)}
+              disabled={loading}
+              required
+            />
+            <textarea
+              className={`${inputCls} resize-none`}
+              rows={3}
+              placeholder={"Parameters (one per line)\ne.g. u32:42\naddress:G...\nbool:true"}
+              value={paramsRaw}
+              onChange={(e) => setParamsRaw(e.target.value)}
+              disabled={loading}
+            />
+          </>
+        )}
+
+        <input
+          className={inputCls}
+          placeholder={mode === "invoke" ? "Invoker public key (G...)" : "Deployer public key (G...)"}
+          value={invokerPublicKey}
+          onChange={(e) => setInvokerPublicKey(e.target.value)}
+          disabled={loading}
+          required
+        />
+
+        <Button
+          type="submit"
+          disabled={loading}
+          className="bg-yellow-600 hover:bg-yellow-700 text-white text-xs py-1.5"
+        >
+          {loading ? (
+            <span className="flex items-center gap-1.5">
+              <Loader2 className="w-3 h-3 animate-spin" />
+              Simulating…
+            </span>
+          ) : (
+            "Simulate"
+          )}
+        </Button>
+      </form>
+
+      {error && (
+        <div className="p-2 bg-red-900/40 border border-red-700 rounded text-red-300 text-xs flex items-start gap-1.5">
+          <AlertTriangle className="w-3 h-3 shrink-0 mt-0.5" />
+          {error}
+        </div>
+      )}
+
+      {invokeResult && mode === "invoke" && (
+        <div className="flex flex-col gap-3 p-3 bg-[#0D1117] border border-gray-700 rounded text-xs">
+          <div className="flex items-center gap-1.5 text-green-400 font-semibold">
+            <CheckCircle2 className="w-3.5 h-3.5" />
+            Simulation successful
+          </div>
+
+          {invokeResult.simulation_error && (
+            <div className="p-2 bg-yellow-900/40 border border-yellow-700 rounded text-yellow-300 text-xs">
+              <p className="font-semibold mb-1">Contract would revert:</p>
+              <pre className="whitespace-pre-wrap break-all overflow-auto max-h-32 font-mono text-[10px]">
+                {invokeResult.simulation_error}
+              </pre>
+            </div>
+          )}
+
+          <div>
+            <p className="text-gray-500 uppercase text-[10px] tracking-wider mb-1.5">Fee Estimate</p>
+            <div className="flex flex-col gap-1">
+              <FeeRow label="Base fee" stroops={invokeResult.fee.base_fee} />
+              <FeeRow label="Resource fee" stroops={invokeResult.fee.resource_fee} />
+              <div className="border-t border-gray-700 my-1" />
+              <FeeRow label="Total" stroops={invokeResult.fee.total_stroops} highlight />
+            </div>
+          </div>
+
+          <div>
+            <p className="text-gray-500 uppercase text-[10px] tracking-wider mb-1.5">Resource Usage</p>
+            <div className="flex flex-col gap-1">
+              <ResourceRow label="CPU instructions" value={invokeResult.resources.cpu_insns} unit="" />
+              <ResourceRow label="Memory" value={invokeResult.resources.mem_bytes} unit="bytes" />
+              <ResourceRow label="Ledger reads" value={invokeResult.resources.read_bytes} unit="bytes" />
+              <ResourceRow label="Ledger writes" value={invokeResult.resources.write_bytes} unit="bytes" />
+            </div>
+          </div>
+
+          {invokeResult.simulated_result !== null && invokeResult.simulated_result !== undefined && (
+            <div>
+              <p className="text-gray-500 uppercase text-[10px] tracking-wider mb-1">Simulated Return Value</p>
+              <pre className="font-mono text-green-300 text-[11px] whitespace-pre-wrap break-all">
+                {JSON.stringify(invokeResult.simulated_result, null, 2)}
+              </pre>
+            </div>
+          )}
+
+          {invokeResult.auth_entries.length > 0 && (
+            <div>
+              <button
+                type="button"
+                className="flex items-center gap-1 text-gray-400 hover:text-white"
+                onClick={() => setAuthOpen((v) => !v)}
+              >
+                Auth entries ({invokeResult.auth_entries.length})
+                {authOpen ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+              </button>
+              {authOpen && (
+                <div className="mt-1 flex flex-col gap-1">
+                  {invokeResult.auth_entries.map((a, i) => (
+                    <pre key={i} className="font-mono text-[10px] text-gray-400 break-all whitespace-pre-wrap">
+                      {a}
+                    </pre>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {deployResult && mode === "deploy" && (
+        <div className="flex flex-col gap-3 p-3 bg-[#0D1117] border border-gray-700 rounded text-xs">
+          <div className="flex items-center gap-1.5 text-green-400 font-semibold">
+            <CheckCircle2 className="w-3.5 h-3.5" />
+            Deploy simulation complete
+          </div>
+
+          <div>
+            <p className="text-gray-500 uppercase text-[10px] tracking-wider mb-1.5">Upload Fee Estimate</p>
+            <div className="flex flex-col gap-1">
+              <FeeRow label="Base fee" stroops={deployResult.upload_fee.base_fee} />
+              <FeeRow label="Resource fee" stroops={deployResult.upload_fee.resource_fee} />
+              <div className="border-t border-gray-700 my-1" />
+              <FeeRow label="Upload total" stroops={deployResult.upload_fee.total_stroops} highlight />
+            </div>
+          </div>
+
+          <div>
+            <p className="text-gray-500 uppercase text-[10px] tracking-wider mb-1.5">Resource Usage</p>
+            <div className="flex flex-col gap-1">
+              <ResourceRow label="CPU instructions" value={deployResult.upload_fee.resources.cpu_insns} unit="" />
+              <ResourceRow label="Memory" value={deployResult.upload_fee.resources.mem_bytes} unit="bytes" />
+              <ResourceRow label="Ledger reads" value={deployResult.upload_fee.resources.read_bytes} unit="bytes" />
+              <ResourceRow label="Ledger writes" value={deployResult.upload_fee.resources.write_bytes} unit="bytes" />
+            </div>
+          </div>
+
+          <div className="flex justify-between text-xs">
+            <span className="text-gray-400">WASM size</span>
+            <span className="font-mono text-gray-200">
+              {(deployResult.wasm_size_bytes / 1024).toFixed(1)} KB
+            </span>
+          </div>
+
+          <p className="text-gray-500 text-[10px] italic">{deployResult.note}</p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const inputCls =
+  "bg-[#0D1117] border border-gray-600 rounded px-2 py-1.5 text-xs text-white " +
+  "placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-yellow-500 w-full"

--- a/pages/app/index.jsx
+++ b/pages/app/index.jsx
@@ -18,6 +18,7 @@ import {
     User,
     ChevronLeft,
     Zap,
+    Activity,
     Rocket,
     Github,
     GitPullRequest,
@@ -27,6 +28,8 @@ import { Button } from "@/components/ui/button"
 import { getPublicKey, signTransaction, isConnected } from "@stellar/freighter-api"
 import ContractInteraction from "@/components/ContractInteraction"
 import MonacoEditor from "@/components/MonacoEditor"
+import SimulationPanel from "@/components/SimulationPanel"
+import ContractEventLog from "@/components/ContractEventLog"
 
 // ── Config ─────────────────────────────────────────────────────────────────────
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:5000"
@@ -181,6 +184,9 @@ export default function IDEApp() {
     ])
     const [activeEditorPath, setActiveEditorPath] = useState("/workspace/src/contract.rs")
 
+    // ── Soroban session ────────────────────────────────────────────────────────
+    const [sorobanSessionId, setSorobanSessionId] = useState(null)
+
     // ── Deploy state ───────────────────────────────────────────────────────────
     const [isDeploying, setIsDeploying] = useState(false)
     const [contractId, setContractId]   = useState(null)
@@ -245,7 +251,29 @@ export default function IDEApp() {
                 return
             }
             setUser(userData)
-            
+
+            // Fetch or create a Soroban session for this user
+            try {
+                const sessRes = await fetch(`${BACKEND_URL}/sessions`, {
+                    headers: { Authorization: `Bearer ${token}` }
+                })
+                const sessData = await sessRes.json()
+                if (sessData.success && sessData.sessions && sessData.sessions.length > 0) {
+                    setSorobanSessionId(sessData.sessions[0].session_id)
+                } else {
+                    // Create a new session
+                    const newSess = await fetch(`${BACKEND_URL}/`, {
+                        headers: { Authorization: `Bearer ${token}` }
+                    })
+                    const newSessData = await newSess.json()
+                    if (newSessData.session && newSessData.session.session_id) {
+                        setSorobanSessionId(newSessData.session.session_id)
+                    }
+                }
+            } catch (err) {
+                console.warn("Failed to fetch soroban session", err)
+            }
+
             // Auto-setup or retrieve default project workspace
             try {
                 const projRes = await fetch(`${BACKEND_URL}/api/projects/list`, {
@@ -795,30 +823,26 @@ export default function IDEApp() {
                                     : "relative w-0 overflow-hidden",
                         ].join(" ")}
                     >
-                        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700 min-h-[48px]">
-                            <div className="flex gap-1">
-                                <button
-                                    onClick={() => setSidebarTab("explorer")}
-                                    className={`flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors ${
-                                        sidebarTab === "explorer"
-                                            ? "bg-gray-700 text-white"
-                                            : "text-gray-400 hover:text-white"
-                                    }`}
-                                >
-                                    <FolderOpen className="w-3 h-3" />
-                                    Explorer
-                                </button>
-                                <button
-                                    onClick={() => setSidebarTab("contract")}
-                                    className={`flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors ${
-                                        sidebarTab === "contract"
-                                            ? "bg-gray-700 text-white"
-                                            : "text-gray-400 hover:text-white"
-                                    }`}
-                                >
-                                    <Zap className="w-3 h-3" />
-                                    Contract
-                                </button>
+                        <div className="flex items-center justify-between px-2 py-2 border-b border-gray-700 min-h-[44px]">
+                            <div className="flex gap-0.5 overflow-x-auto scrollbar-none flex-1 min-w-0">
+                                {[
+                                    { id: "explorer", icon: <FolderOpen className="w-3 h-3 shrink-0" />, label: "Files" },
+                                    { id: "contract", icon: <Zap className="w-3 h-3 shrink-0" />, label: "Deploy" },
+                                    { id: "simulate", icon: <Zap className="w-3 h-3 shrink-0 text-yellow-400" />, label: "Sim" },
+                                    { id: "events",   icon: <Activity className="w-3 h-3 shrink-0 text-purple-400" />, label: "Events" },
+                                ].map(({ id, icon, label }) => (
+                                    <button
+                                        key={id}
+                                        onClick={() => setSidebarTab(id)}
+                                        className={`flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors whitespace-nowrap shrink-0 ${
+                                            sidebarTab === id
+                                                ? "bg-gray-700 text-white"
+                                                : "text-gray-400 hover:text-white"
+                                        }`}
+                                    >
+                                        {icon}{label}
+                                    </button>
+                                ))}
                             </div>
                             <Button
                                 variant="ghost"
@@ -862,6 +886,31 @@ export default function IDEApp() {
                                     sessionId={null}
                                     authToken={null}
                                 />
+                            )}
+
+                            {sidebarTab === "simulate" && (
+                                sorobanSessionId ? (
+                                    <SimulationPanel
+                                        sessionId={sorobanSessionId}
+                                        authToken={getToken()}
+                                        apiBaseUrl={BACKEND_URL}
+                                        mode="invoke"
+                                    />
+                                ) : (
+                                    <p className="p-4 text-xs text-gray-500">Setting up session…</p>
+                                )
+                            )}
+
+                            {sidebarTab === "events" && (
+                                sorobanSessionId ? (
+                                    <ContractEventLog
+                                        sessionId={sorobanSessionId}
+                                        authToken={getToken()}
+                                        apiBaseUrl={BACKEND_URL}
+                                    />
+                                ) : (
+                                    <p className="p-4 text-xs text-gray-500">Setting up session…</p>
+                                )
                             )}
                         </div>
 

--- a/pages/login.jsx
+++ b/pages/login.jsx
@@ -39,7 +39,7 @@ export default function LoginPage() {
             : `${BACKEND_URL}/api/auth/register`
 
         const body = tab === "login"
-            ? { email, password }
+            ? { login: email, password }
             : { email, username, password }
 
         try {

--- a/server/routes/soroban_invoke.py
+++ b/server/routes/soroban_invoke.py
@@ -5,6 +5,7 @@ Addresses issue #58.
 Endpoints:
   POST /api/soroban/invoke                           — call a contract function
   GET  /api/soroban/invocations/<session_id>         — list invocation history
+  GET  /api/soroban/events/<session_id>              — contract events from invocations
   GET  /api/soroban/state/<session_id>/<contract_id> — read contract ledger state
 """
 
@@ -119,6 +120,59 @@ def _scval_to_python(val) -> object:
         return repr(val)
     except Exception:
         return repr(val)
+
+
+def _extract_soroban_events(result_meta_xdr: str) -> list[dict]:
+    """
+    Decode contract events emitted during a Soroban transaction.
+
+    Parses the TransactionMetaV3.soroban_meta.events field from the
+    result_meta_xdr returned by get_transaction. Only CONTRACT and SYSTEM
+    events are included; DIAGNOSTIC events are filtered out.
+
+    Returns a list of dicts with keys: type, contract_id, topics, data.
+    Returns an empty list if the XDR cannot be parsed or contains no events.
+    """
+    if not result_meta_xdr:
+        return []
+    try:
+        from stellar_sdk import xdr as stellar_xdr, StrKey
+
+        meta = stellar_xdr.TransactionMeta.from_xdr(result_meta_xdr)
+        if not (meta.v3 and meta.v3.soroban_meta):
+            return []
+
+        decoded_events = []
+        for event in meta.v3.soroban_meta.events:
+            event_type = event.type.name  # "CONTRACT", "SYSTEM", "DIAGNOSTIC"
+            if event_type == "DIAGNOSTIC":
+                continue
+
+            contract_id = None
+            if event.contract_id:
+                try:
+                    contract_id = StrKey.encode_contract(event.contract_id.hash)
+                except Exception:
+                    contract_id = event.contract_id.hash.hex()
+
+            topics: list = []
+            data = None
+            if event.body and event.body.v0:
+                v0 = event.body.v0
+                topics = [_scval_to_python(t) for t in (v0.topics.sc_vec or [])]
+                data = _scval_to_python(v0.data)
+
+            decoded_events.append({
+                "type": event_type,
+                "contract_id": contract_id,
+                "topics": topics,
+                "data": data,
+            })
+
+        return decoded_events
+    except Exception:
+        logger.debug("Failed to extract Soroban events from result_meta_xdr", exc_info=True)
+        return []
 
 
 def _save_invocation_record(instance_dir: str, record: dict) -> None:
@@ -255,11 +309,14 @@ def invoke_contract(current_user):
                 "transaction_hash": send_resp.hash,
             }), 422
 
+        events = _extract_soroban_events(invoke_result.get("result_meta_xdr") or "")
+
         record = {
             "contract_id": contract_id,
             "function_name": function_name,
             "parameters": parameters,
             "result": invoke_result.get("result"),
+            "events": events,
             "transaction_hash": send_resp.hash,
             "invoker_public_key": invoker_public,
             "network": "testnet",
@@ -276,6 +333,7 @@ def invoke_contract(current_user):
             "success": True,
             **record,
             "explorer_url": f"https://stellar.expert/explorer/testnet/tx/{send_resp.hash}",
+            "event_count": len(events),
         }), 200
 
     except Exception as e:
@@ -327,6 +385,78 @@ def list_invocations(current_user, session_id):
             "session_id": session_id,
         })
         return jsonify({"success": False, "error": "An error occurred while listing invocations"}), 500
+
+
+# ---------------------------------------------------------------------------
+# GET /api/soroban/events/<session_id>
+# ---------------------------------------------------------------------------
+
+@soroban_invoke_bp.route("/events/<int:session_id>", methods=["GET"])
+@token_required
+def list_contract_events(current_user, session_id):
+    """
+    Return all Soroban contract events emitted across a session's invocations.
+
+    Reads event data persisted in invocation records (populated since this
+    feature was added). Supports optional filtering by contract_id.
+
+    Query params:
+        contract_id (str) — optional: filter events to a specific contract
+
+    Response JSON:
+        success, events (list), total (int)
+
+    Each event dict contains:
+        transaction_hash, timestamp, invoked_function,
+        type, contract_id, topics, data
+    """
+    try:
+        session = Session.query.filter_by(
+            id=session_id, user_id=current_user.id, is_active=True
+        ).first()
+        if not session:
+            return jsonify({"success": False, "error": "Session not found or access denied"}), 404
+
+        instance_dir = session.instance_dir
+        if not instance_dir or not os.path.isdir(instance_dir):
+            return jsonify({"success": True, "events": [], "total": 0}), 200
+
+        filter_contract = (request.args.get("contract_id") or "").strip() or None
+
+        inv_dir = os.path.join(instance_dir, ".invocations")
+        all_events: list[dict] = []
+
+        if os.path.isdir(inv_dir):
+            for f in sorted(Path(inv_dir).glob("*.json")):
+                try:
+                    record = json.loads(f.read_text())
+                except Exception:
+                    continue
+
+                for event in record.get("events") or []:
+                    if filter_contract and event.get("contract_id") != filter_contract:
+                        continue
+                    all_events.append({
+                        "transaction_hash": record.get("transaction_hash"),
+                        "timestamp": record.get("timestamp"),
+                        "invoked_function": record.get("function_name"),
+                        **event,
+                    })
+
+        return jsonify({
+            "success": True,
+            "events": all_events,
+            "total": len(all_events),
+        }), 200
+
+    except Exception as e:
+        logger.exception("list_contract_events error")
+        capture_exception(e, {
+            "route": "soroban_invoke.list_contract_events",
+            "user_id": current_user.id,
+            "session_id": session_id,
+        })
+        return jsonify({"success": False, "error": "An error occurred while listing events"}), 500
 
 
 # ---------------------------------------------------------------------------
@@ -433,7 +563,11 @@ def _wait_for_transaction(server, tx_hash: str, max_attempts: int = 10) -> dict:
                         decoded = _scval_to_python(val)
                 except Exception:
                     decoded = result.return_value
-                return {"success": True, "result": decoded}
+                return {
+                    "success": True,
+                    "result": decoded,
+                    "result_meta_xdr": getattr(result, "result_meta_xdr", None),
+                }
             if result.status == GetTransactionStatus.FAILED:
                 return {"success": False, "error": "Transaction failed on-chain"}
         except Exception as exc:

--- a/server/routes/soroban_simulate.py
+++ b/server/routes/soroban_simulate.py
@@ -1,0 +1,437 @@
+"""
+Soroban transaction pre-flight simulation routes.
+
+Simulates contract invocations and WASM deployments against the RPC node
+without submitting any transaction. Returns fee estimates, resource
+footprints, and — for invoke simulations — the expected return value.
+
+Endpoints:
+  POST /api/soroban/simulate/invoke   — simulate a contract function call
+  POST /api/soroban/simulate/deploy   — simulate WASM upload fee estimation
+"""
+
+import os
+import logging
+from flask import Blueprint, request, jsonify
+from server.utils.auth_utils import token_required
+from server.utils.monitoring import capture_exception
+
+try:
+    from server.models import Session
+except Exception:
+    Session = None  # type: ignore
+
+soroban_simulate_bp = Blueprint(
+    "soroban_simulate", __name__, url_prefix="/api/soroban/simulate"
+)
+logger = logging.getLogger(__name__)
+
+_NETWORK_CONFIG = {
+    "testnet": {
+        "rpc": "https://soroban-testnet.stellar.org",
+        "passphrase": "Test SDF Network ; September 2015",
+    },
+    "mainnet": {
+        "rpc": "https://mainnet.sorobanrpc.com",
+        "passphrase": "Public Global Stellar Network ; September 2015",
+    },
+}
+
+_BASE_FEE_STROOPS = 100
+_STROOPS_PER_XLM = 10_000_000
+
+
+def _get_stellar_sdk():
+    try:
+        from stellar_sdk import Keypair, SorobanServer, TransactionBuilder  # noqa: F401
+        return True, None
+    except ImportError:
+        return False, (
+            "stellar-sdk is not installed. "
+            "Add 'stellar-sdk>=11.0.0' to server/requirements.txt and reinstall."
+        )
+
+
+def _parse_param(raw: str):
+    """Convert a typed string parameter to the appropriate SCVal."""
+    from stellar_sdk import scval, Address
+
+    raw = raw.strip()
+    if ":" in raw:
+        prefix, _, value = raw.partition(":")
+        prefix = prefix.lower()
+        dispatch = {
+            "u32": lambda v: scval.to_uint32(int(v)),
+            "u64": lambda v: scval.to_uint64(int(v)),
+            "i32": lambda v: scval.to_int32(int(v)),
+            "i64": lambda v: scval.to_int64(int(v)),
+            "bool": lambda v: scval.to_bool(v.lower() == "true"),
+            "address": lambda v: scval.to_address(Address(v)),
+            "bytes": lambda v: scval.to_bytes(bytes.fromhex(v)),
+            "sym": lambda v: scval.to_symbol(v),
+            "str": lambda v: scval.to_string(v),
+        }
+        if prefix in dispatch:
+            return dispatch[prefix](value)
+    return scval.to_string(raw)
+
+
+def _decode_sim_response(sim_response) -> dict:
+    """
+    Extract fee estimates, resource usage, and simulated return value
+    from a SimulateTransactionResponse.
+    """
+    resource_fee = int(getattr(sim_response, "min_resource_fee", 0) or 0)
+    cpu_insns = 0
+    mem_bytes = 0
+    read_bytes = 0
+    write_bytes = 0
+
+    cost = getattr(sim_response, "cost", None)
+    if cost:
+        cpu_insns = int(getattr(cost, "cpu_insns", 0) or 0)
+        mem_bytes = int(getattr(cost, "mem_bytes", 0) or 0)
+
+    tx_data = getattr(sim_response, "transaction_data", None)
+    if tx_data:
+        try:
+            resources = getattr(tx_data, "resources", None)
+            if resources:
+                read_bytes = int(getattr(resources, "read_bytes", 0) or 0)
+                write_bytes = int(getattr(resources, "write_bytes", 0) or 0)
+        except Exception:
+            pass
+
+    simulated_result = None
+    auth_entries: list[str] = []
+
+    results = getattr(sim_response, "results", None) or []
+    if results:
+        first = results[0]
+        xdr_val = getattr(first, "xdr", None)
+        if xdr_val:
+            try:
+                from stellar_sdk import xdr as stellar_xdr
+                from server.routes.soroban_invoke import _scval_to_python
+                simulated_result = _scval_to_python(
+                    stellar_xdr.SCVal.from_xdr(xdr_val)
+                )
+            except Exception:
+                simulated_result = xdr_val
+
+        raw_auth = getattr(first, "auth", None) or []
+        auth_entries = [str(a) for a in raw_auth]
+
+    return {
+        "resource_fee": resource_fee,
+        "cpu_insns": cpu_insns,
+        "mem_bytes": mem_bytes,
+        "read_bytes": read_bytes,
+        "write_bytes": write_bytes,
+        "simulated_result": simulated_result,
+        "auth_entries": auth_entries,
+        "sim_error": getattr(sim_response, "error", None),
+    }
+
+
+def _fee_summary(resource_fee: int) -> dict:
+    total = _BASE_FEE_STROOPS + resource_fee
+    return {
+        "base_fee": _BASE_FEE_STROOPS,
+        "resource_fee": resource_fee,
+        "total_stroops": total,
+        "xlm": f"{total / _STROOPS_PER_XLM:.7f}",
+    }
+
+
+# ---------------------------------------------------------------------------
+# POST /api/soroban/simulate/invoke
+# ---------------------------------------------------------------------------
+
+@soroban_simulate_bp.route("/invoke", methods=["POST"])
+@token_required
+def simulate_invoke(current_user):
+    """
+    Simulate a Soroban contract function call.
+
+    No transaction is submitted; this is a pure read-only preflight
+    against the Soroban RPC simulate_transaction endpoint.
+
+    Request JSON:
+        session_id          (int)       — active session ID
+        contract_id         (str)       — deployed contract address (C...)
+        function_name       (str)       — function to simulate
+        parameters          (list[str]) — typed params e.g. ["u32:42", "bool:true"]
+        invoker_public_key  (str)       — Stellar public key (G...)
+        network             (str)       — "testnet" | "mainnet" (default: "testnet")
+
+    Response JSON:
+        success             (bool)
+        fee                 (dict)  — base_fee, resource_fee, total_stroops, xlm
+        resources           (dict)  — cpu_insns, mem_bytes, read_bytes, write_bytes
+        simulated_result    (any)   — decoded return value from simulation
+        auth_entries        (list)  — auth entries this call requires
+        network             (str)
+        simulation_error    (str|null) — RPC-level error, if the call would revert
+    """
+    try:
+        data = request.get_json(silent=True, force=True)
+        if not data:
+            return jsonify({"success": False, "error": "No data provided"}), 400
+
+        session_id = data.get("session_id")
+        contract_id = (data.get("contract_id") or "").strip()
+        function_name = (data.get("function_name") or "").strip()
+        invoker_public_key = (data.get("invoker_public_key") or "").strip()
+        parameters = data.get("parameters") or []
+        network = (data.get("network") or "testnet").lower()
+
+        if not session_id:
+            return jsonify({"success": False, "error": "session_id is required"}), 400
+        if not contract_id:
+            return jsonify({"success": False, "error": "contract_id is required"}), 400
+        if not function_name:
+            return jsonify({"success": False, "error": "function_name is required"}), 400
+        if not invoker_public_key:
+            return jsonify({"success": False, "error": "invoker_public_key is required"}), 400
+        if not isinstance(parameters, list):
+            return jsonify({"success": False, "error": "parameters must be a list"}), 400
+        if network not in _NETWORK_CONFIG:
+            return jsonify({
+                "success": False,
+                "error": f"Unsupported network '{network}'. Use 'testnet' or 'mainnet'",
+            }), 400
+
+        session = Session.query.filter_by(
+            id=session_id, user_id=current_user.id, is_active=True
+        ).first()
+        if not session:
+            return jsonify({"success": False, "error": "Session not found or access denied"}), 404
+
+        sdk_ok, sdk_err = _get_stellar_sdk()
+        if not sdk_ok:
+            return jsonify({"success": False, "error": sdk_err}), 500
+
+        from stellar_sdk import Keypair, SorobanServer, TransactionBuilder
+
+        try:
+            Keypair.from_public_key(invoker_public_key)
+        except Exception:
+            return jsonify({"success": False, "error": "Invalid invoker_public_key"}), 400
+
+        try:
+            sc_params = [_parse_param(p) for p in parameters]
+        except Exception as exc:
+            return jsonify({"success": False, "error": f"Invalid parameter format: {exc}"}), 400
+
+        cfg = _NETWORK_CONFIG[network]
+        server = SorobanServer(cfg["rpc"])
+
+        try:
+            source_account = server.load_account(invoker_public_key)
+        except Exception as exc:
+            return jsonify({
+                "success": False,
+                "error": (
+                    f"Could not load account {invoker_public_key}: {exc}. "
+                    "Ensure the account is funded on this network."
+                ),
+            }), 422
+
+        tx = (
+            TransactionBuilder(
+                source_account=source_account,
+                network_passphrase=cfg["passphrase"],
+                base_fee=_BASE_FEE_STROOPS,
+            )
+            .set_timeout(30)
+            .append_invoke_contract_function_op(
+                contract_id=contract_id,
+                function_name=function_name,
+                parameters=sc_params,
+            )
+            .build()
+        )
+
+        try:
+            sim_response = server.simulate_transaction(tx)
+        except Exception as exc:
+            return jsonify({"success": False, "error": f"RPC simulation failed: {exc}"}), 502
+
+        decoded = _decode_sim_response(sim_response)
+
+        logger.info(
+            "simulate_invoke: user=%s contract=%s fn=%s fee=%d stroops network=%s",
+            current_user.username,
+            contract_id,
+            function_name,
+            _BASE_FEE_STROOPS + decoded["resource_fee"],
+            network,
+        )
+
+        return jsonify({
+            "success": True,
+            "fee": _fee_summary(decoded["resource_fee"]),
+            "resources": {
+                "cpu_insns": decoded["cpu_insns"],
+                "mem_bytes": decoded["mem_bytes"],
+                "read_bytes": decoded["read_bytes"],
+                "write_bytes": decoded["write_bytes"],
+            },
+            "simulated_result": decoded["simulated_result"],
+            "auth_entries": decoded["auth_entries"],
+            "network": network,
+            "simulation_error": decoded["sim_error"],
+        }), 200
+
+    except Exception as e:
+        logger.exception("simulate_invoke error")
+        capture_exception(e, {
+            "route": "soroban_simulate.simulate_invoke",
+            "user_id": current_user.id,
+        })
+        return jsonify({"success": False, "error": "An error occurred during simulation"}), 500
+
+
+# ---------------------------------------------------------------------------
+# POST /api/soroban/simulate/deploy
+# ---------------------------------------------------------------------------
+
+@soroban_simulate_bp.route("/deploy", methods=["POST"])
+@token_required
+def simulate_deploy(current_user):
+    """
+    Simulate the WASM upload step of a Soroban contract deployment.
+
+    The contract creation step fee depends on the resulting WASM hash
+    (computed after upload) so only the upload fee can be pre-flighted.
+    The response includes a conservative combined estimate.
+
+    Request JSON:
+        session_id           (int)  — active session ID
+        wasm_path            (str)  — relative path to .wasm inside session workspace
+        deployer_public_key  (str)  — Stellar public key (G...)
+        network              (str)  — "testnet" | "mainnet" (default: "testnet")
+
+    Response JSON:
+        success              (bool)
+        upload_fee           (dict) — fee breakdown for the WASM upload step
+        wasm_size_bytes      (int)
+        network              (str)
+        note                 (str)  — explains the create_fee estimation limitation
+    """
+    try:
+        data = request.get_json(silent=True, force=True)
+        if not data:
+            return jsonify({"success": False, "error": "No data provided"}), 400
+
+        session_id = data.get("session_id")
+        wasm_path_raw = (data.get("wasm_path") or "").strip()
+        deployer_public_key = (data.get("deployer_public_key") or "").strip()
+        network = (data.get("network") or "testnet").lower()
+
+        if not session_id:
+            return jsonify({"success": False, "error": "session_id is required"}), 400
+        if not wasm_path_raw:
+            return jsonify({"success": False, "error": "wasm_path is required"}), 400
+        if not deployer_public_key:
+            return jsonify({"success": False, "error": "deployer_public_key is required"}), 400
+        if network not in _NETWORK_CONFIG:
+            return jsonify({"success": False, "error": f"Unsupported network '{network}'"}), 400
+
+        session = Session.query.filter_by(
+            id=session_id, user_id=current_user.id, is_active=True
+        ).first()
+        if not session:
+            return jsonify({"success": False, "error": "Session not found or access denied"}), 404
+
+        instance_dir = session.instance_dir
+        if not instance_dir or not os.path.isdir(instance_dir):
+            return jsonify({"success": False, "error": "Session workspace not found"}), 404
+
+        from server.routes.soroban_deploy import _resolve_wasm_path
+        wasm_path = _resolve_wasm_path(wasm_path_raw, instance_dir)
+        if not wasm_path or not os.path.isfile(wasm_path):
+            return jsonify({
+                "success": False,
+                "error": f"WASM file not found: {wasm_path_raw}. Compile the contract first.",
+            }), 404
+
+        sdk_ok, sdk_err = _get_stellar_sdk()
+        if not sdk_ok:
+            return jsonify({"success": False, "error": sdk_err}), 500
+
+        from stellar_sdk import Keypair, SorobanServer, TransactionBuilder
+
+        try:
+            Keypair.from_public_key(deployer_public_key)
+        except Exception:
+            return jsonify({"success": False, "error": "Invalid deployer_public_key"}), 400
+
+        cfg = _NETWORK_CONFIG[network]
+        server = SorobanServer(cfg["rpc"])
+
+        try:
+            source_account = server.load_account(deployer_public_key)
+        except Exception as exc:
+            return jsonify({
+                "success": False,
+                "error": f"Could not load account {deployer_public_key}: {exc}",
+            }), 422
+
+        with open(wasm_path, "rb") as f:
+            wasm_bytes = f.read()
+
+        upload_tx = (
+            TransactionBuilder(
+                source_account=source_account,
+                network_passphrase=cfg["passphrase"],
+                base_fee=_BASE_FEE_STROOPS,
+            )
+            .set_timeout(30)
+            .append_upload_contract_wasm_op(wasm=wasm_bytes)
+            .build()
+        )
+
+        try:
+            sim_response = server.simulate_transaction(upload_tx)
+        except Exception as exc:
+            return jsonify({"success": False, "error": f"Upload simulation failed: {exc}"}), 502
+
+        decoded = _decode_sim_response(sim_response)
+        upload_fee = _fee_summary(decoded["resource_fee"])
+
+        logger.info(
+            "simulate_deploy: user=%s wasm_size=%d upload_fee=%d stroops network=%s",
+            current_user.username,
+            len(wasm_bytes),
+            upload_fee["total_stroops"],
+            network,
+        )
+
+        return jsonify({
+            "success": True,
+            "upload_fee": {
+                **upload_fee,
+                "resources": {
+                    "cpu_insns": decoded["cpu_insns"],
+                    "mem_bytes": decoded["mem_bytes"],
+                    "read_bytes": decoded["read_bytes"],
+                    "write_bytes": decoded["write_bytes"],
+                },
+            },
+            "wasm_size_bytes": len(wasm_bytes),
+            "network": network,
+            "note": (
+                "create_fee depends on the uploaded WASM hash and can only be "
+                "estimated after the upload transaction is confirmed."
+            ),
+        }), 200
+
+    except Exception as e:
+        logger.exception("simulate_deploy error")
+        capture_exception(e, {
+            "route": "soroban_simulate.simulate_deploy",
+            "user_id": current_user.id,
+        })
+        return jsonify({"success": False, "error": "An error occurred during simulation"}), 500

--- a/server/start.py
+++ b/server/start.py
@@ -23,6 +23,8 @@ from server.routes.project_routes import project_bp
 from server.routes.soroban_deploy import soroban_deploy_bp
 from server.routes.soroban_invoke import soroban_invoke_bp
 from server.routes.soroban_wallet import wallet_bp
+from server.routes.soroban_simulate import soroban_simulate_bp
+from server.routes.soroban_prompt_routes import soroban_prompts_bp
 from server.utils import token_required, secure_execute, SecurityError
 from server.utils.db_utils import create_session_for_user, add_chat_message, ensure_database_directory, get_database_stats
 from server.utils.monitoring import setup_logging, init_sentry, monitor_endpoint, get_monitoring_stats
@@ -91,6 +93,8 @@ app.register_blueprint(templates_bp)
 app.register_blueprint(soroban_deploy_bp)
 app.register_blueprint(soroban_invoke_bp)
 app.register_blueprint(wallet_bp)
+app.register_blueprint(soroban_simulate_bp)
+app.register_blueprint(soroban_prompts_bp)
 
 if LIMITER_AVAILABLE and os.getenv('RATE_LIMIT_ENABLED', 'true').lower() == 'true':
     limiter = Limiter(

--- a/server/tests/test_soroban_invoke.py
+++ b/server/tests/test_soroban_invoke.py
@@ -252,6 +252,160 @@ class TestGetContractState:
 # Unit tests for helpers
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# GET /api/soroban/events/<session_id>
+# ---------------------------------------------------------------------------
+
+class TestListContractEvents:
+    def test_session_not_found(self, client):
+        m.Session = _no_session()
+        resp = client.get("/api/soroban/events/99")
+        assert resp.status_code == 404
+
+    def test_empty_when_no_invocations(self, client, tmp_path):
+        d = str(tmp_path / "inst")
+        os.makedirs(d)
+        m.Session = _yes_session(d)
+        resp = client.get("/api/soroban/events/1")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["events"] == []
+        assert data["total"] == 0
+
+    def test_returns_events_from_invocation_records(self, client, tmp_path):
+        d = str(tmp_path / "inst")
+        os.makedirs(d)
+        inv_dir = tmp_path / "inst" / ".invocations"
+        os.makedirs(inv_dir)
+
+        record = {
+            "contract_id": "CTEST123",
+            "function_name": "transfer",
+            "transaction_hash": "abc123",
+            "timestamp": "2026-04-29T10:00:00+00:00",
+            "events": [
+                {
+                    "type": "CONTRACT",
+                    "contract_id": "CTEST123",
+                    "topics": ["transfer"],
+                    "data": {"amount": 100},
+                }
+            ],
+        }
+        (inv_dir / "invoke_20260429T100000000000.json").write_text(
+            json.dumps(record)
+        )
+        m.Session = _yes_session(d)
+        resp = client.get("/api/soroban/events/1")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] == 1
+        evt = data["events"][0]
+        assert evt["type"] == "CONTRACT"
+        assert evt["contract_id"] == "CTEST123"
+        assert evt["topics"] == ["transfer"]
+        assert evt["transaction_hash"] == "abc123"
+        assert evt["invoked_function"] == "transfer"
+
+    def test_filter_by_contract_id(self, client, tmp_path):
+        d = str(tmp_path / "inst")
+        os.makedirs(d)
+        inv_dir = tmp_path / "inst" / ".invocations"
+        os.makedirs(inv_dir)
+
+        for i, cid in enumerate(["CAAAA", "CBBBB"]):
+            record = {
+                "contract_id": cid,
+                "function_name": "fn",
+                "transaction_hash": f"tx{i}",
+                "timestamp": "2026-04-29T10:00:00+00:00",
+                "events": [
+                    {"type": "CONTRACT", "contract_id": cid, "topics": ["evt"], "data": None}
+                ],
+            }
+            (inv_dir / f"invoke_2026042900000000000{i}.json").write_text(json.dumps(record))
+
+        m.Session = _yes_session(d)
+        resp = client.get("/api/soroban/events/1?contract_id=CAAAA")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] == 1
+        assert data["events"][0]["contract_id"] == "CAAAA"
+
+    def test_invocations_without_events_field_are_skipped(self, client, tmp_path):
+        d = str(tmp_path / "inst")
+        os.makedirs(d)
+        inv_dir = tmp_path / "inst" / ".invocations"
+        os.makedirs(inv_dir)
+
+        # Old-style record without events field
+        record = {
+            "contract_id": "CTEST",
+            "function_name": "hello",
+            "transaction_hash": "abc",
+        }
+        (inv_dir / "invoke_20260429T000000000000.json").write_text(json.dumps(record))
+
+        m.Session = _yes_session(d)
+        resp = client.get("/api/soroban/events/1")
+        assert resp.status_code == 200
+        assert resp.get_json()["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _extract_soroban_events
+# ---------------------------------------------------------------------------
+
+class TestExtractSorobanEvents:
+    def test_empty_string_returns_empty(self):
+        assert m._extract_soroban_events("") == []
+
+    def test_none_returns_empty(self):
+        assert m._extract_soroban_events(None) == []  # type: ignore[arg-type]
+
+    def test_invalid_xdr_returns_empty(self):
+        assert m._extract_soroban_events("not-valid-xdr") == []
+
+    def test_diagnostic_events_are_filtered(self):
+        mock_event = MagicMock()
+        mock_event.type.name = "DIAGNOSTIC"
+
+        mock_meta = MagicMock()
+        mock_meta.v3.soroban_meta.events = [mock_event]
+
+        with patch("stellar_sdk.xdr.TransactionMeta.from_xdr", return_value=mock_meta), \
+             patch("stellar_sdk.StrKey"):
+            result = m._extract_soroban_events("fakexdr")
+
+        assert result == []
+
+    def test_contract_event_decoded(self):
+        from stellar_sdk import scval
+
+        mock_topic_val = MagicMock()
+        mock_data_val = MagicMock()
+
+        mock_event = MagicMock()
+        mock_event.type.name = "CONTRACT"
+        mock_event.contract_id = None
+        mock_event.body.v0.topics.sc_vec = [mock_topic_val]
+        mock_event.body.v0.data = mock_data_val
+
+        mock_meta = MagicMock()
+        mock_meta.v3.soroban_meta.events = [mock_event]
+
+        with patch("stellar_sdk.xdr.TransactionMeta.from_xdr", return_value=mock_meta), \
+             patch.object(m, "_scval_to_python", side_effect=["transfer_topic", "transfer_data"]):
+            result = m._extract_soroban_events("fakexdr")
+
+        assert len(result) == 1
+        assert result[0]["type"] == "CONTRACT"
+        assert result[0]["contract_id"] is None
+        assert result[0]["topics"] == ["transfer_topic"]
+        assert result[0]["data"] == "transfer_data"
+
+
 class TestParseParam:
     def test_u32(self):
         from stellar_sdk import scval

--- a/server/tests/test_soroban_simulate.py
+++ b/server/tests/test_soroban_simulate.py
@@ -1,0 +1,551 @@
+"""Tests for server/routes/soroban_simulate.py"""
+
+import functools
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+from flask import Flask
+
+
+# ---------------------------------------------------------------------------
+# Stub auth / models / monitoring so we can import the module under test
+# without a live database or Stellar SDK
+# ---------------------------------------------------------------------------
+
+def _passthrough(f):
+    @functools.wraps(f)
+    def inner(*args, **kwargs):
+        u = MagicMock()
+        u.id = 1
+        u.username = "testuser"
+        return f(u, *args, **kwargs)
+    return inner
+
+
+_auth_stub = MagicMock()
+_auth_stub.token_required = _passthrough
+
+_soroban_deploy_stub = MagicMock()
+_soroban_deploy_stub._resolve_wasm_path = MagicMock(return_value=None)
+
+_module_stubs = {
+    "server.utils.auth_utils": _auth_stub,
+    "server.models": MagicMock(),
+    "server.utils.monitoring": MagicMock(),
+    "server.routes.soroban_deploy": _soroban_deploy_stub,
+    "server.routes.soroban_invoke": MagicMock(),
+    # Prevent auth_routes chain from being imported via server.routes.__init__
+    "email_validator": MagicMock(),
+    "flask_migrate": MagicMock(),
+    "flask_sqlalchemy": MagicMock(),
+    "sentry_sdk": MagicMock(),
+    "sentry_sdk.integrations": MagicMock(),
+    "sentry_sdk.integrations.flask": MagicMock(),
+    "google.generativeai": MagicMock(),
+    "google": MagicMock(),
+}
+
+with patch.dict("sys.modules", _module_stubs):
+    import server.routes.soroban_simulate as m
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+def _make_session(instance_dir: str):
+    s = MagicMock()
+    s.id = 1
+    s.user_id = 1
+    s.is_active = True
+    s.instance_dir = instance_dir
+    return s
+
+
+def _session_found(d: str):
+    x = MagicMock()
+    x.query.filter_by.return_value.first.return_value = _make_session(d)
+    return x
+
+
+def _session_not_found():
+    x = MagicMock()
+    x.query.filter_by.return_value.first.return_value = None
+    return x
+
+
+def _sim_response(resource_fee=5000, cpu_insns="1000000", mem_bytes="512000",
+                  error=None, results=None):
+    r = MagicMock()
+    r.min_resource_fee = resource_fee
+    r.cost.cpu_insns = cpu_insns
+    r.cost.mem_bytes = mem_bytes
+    r.error = error
+    r.results = results or []
+    r.transaction_data = None
+    return r
+
+
+@pytest.fixture
+def app():
+    a = Flask(__name__)
+    a.config["TESTING"] = True
+    a.register_blueprint(m.soroban_simulate_bp)
+    return a
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/soroban/simulate/invoke — input validation
+# ---------------------------------------------------------------------------
+
+class TestSimulateInvokeValidation:
+    def test_no_body(self, client):
+        resp = client.post("/api/soroban/simulate/invoke")
+        assert resp.status_code == 400
+
+    def test_missing_session_id(self, client):
+        resp = client.post("/api/soroban/simulate/invoke", json={
+            "contract_id": "CTEST",
+            "function_name": "hello",
+            "invoker_public_key": "G" + "A" * 55,
+        })
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "session_id" in data["error"]
+
+    def test_missing_contract_id(self, client):
+        resp = client.post("/api/soroban/simulate/invoke", json={
+            "session_id": 1,
+            "function_name": "hello",
+            "invoker_public_key": "G" + "A" * 55,
+        })
+        assert resp.status_code == 400
+        assert "contract_id" in resp.get_json()["error"]
+
+    def test_missing_function_name(self, client):
+        resp = client.post("/api/soroban/simulate/invoke", json={
+            "session_id": 1,
+            "contract_id": "CTEST",
+            "invoker_public_key": "G" + "A" * 55,
+        })
+        assert resp.status_code == 400
+        assert "function_name" in resp.get_json()["error"]
+
+    def test_missing_invoker_public_key(self, client):
+        resp = client.post("/api/soroban/simulate/invoke", json={
+            "session_id": 1,
+            "contract_id": "CTEST",
+            "function_name": "hello",
+        })
+        assert resp.status_code == 400
+        assert "invoker_public_key" in resp.get_json()["error"]
+
+    def test_parameters_not_a_list(self, client, tmp_path):
+        d = str(tmp_path / "inst")
+        os.makedirs(d)
+        m.Session = _session_found(d)
+        resp = client.post("/api/soroban/simulate/invoke", json={
+            "session_id": 1,
+            "contract_id": "CTEST",
+            "function_name": "hello",
+            "invoker_public_key": "G" + "A" * 55,
+            "parameters": "not-a-list",
+        })
+        assert resp.status_code == 400
+        assert "parameters" in resp.get_json()["error"]
+
+    def test_unsupported_network(self, client, tmp_path):
+        d = str(tmp_path / "inst")
+        os.makedirs(d)
+        m.Session = _session_found(d)
+        resp = client.post("/api/soroban/simulate/invoke", json={
+            "session_id": 1,
+            "contract_id": "CTEST",
+            "function_name": "hello",
+            "invoker_public_key": "G" + "A" * 55,
+            "network": "devnet",
+        })
+        assert resp.status_code == 400
+        assert "network" in resp.get_json()["error"].lower()
+
+    def test_session_not_found(self, client):
+        m.Session = _session_not_found()
+        resp = client.post("/api/soroban/simulate/invoke", json={
+            "session_id": 99,
+            "contract_id": "CTEST",
+            "function_name": "hello",
+            "invoker_public_key": "G" + "A" * 55,
+        })
+        assert resp.status_code == 404
+
+    def test_stellar_sdk_missing(self, client, tmp_path):
+        d = str(tmp_path / "inst")
+        os.makedirs(d)
+        m.Session = _session_found(d)
+        m._get_stellar_sdk = lambda: (False, "stellar-sdk is not installed")
+        resp = client.post("/api/soroban/simulate/invoke", json={
+            "session_id": 1,
+            "contract_id": "CTEST",
+            "function_name": "hello",
+            "invoker_public_key": "G" + "A" * 55,
+        })
+        assert resp.status_code == 500
+        assert "stellar-sdk" in resp.get_json()["error"]
+
+    def test_invalid_public_key(self, client, tmp_path):
+        d = str(tmp_path / "inst")
+        os.makedirs(d)
+        m.Session = _session_found(d)
+        m._get_stellar_sdk = lambda: (True, None)
+
+        with patch("stellar_sdk.Keypair.from_public_key", side_effect=Exception("bad key")):
+            resp = client.post("/api/soroban/simulate/invoke", json={
+                "session_id": 1,
+                "contract_id": "CTEST",
+                "function_name": "hello",
+                "invoker_public_key": "NOTAKEY",
+            })
+        assert resp.status_code == 400
+        assert "invoker_public_key" in resp.get_json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/soroban/simulate/invoke — happy path
+# ---------------------------------------------------------------------------
+
+class TestSimulateInvokeSuccess:
+    _VALID_PUBKEY = "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV73AAUG4HA"
+
+    def _setup(self, tmp_path):
+        d = str(tmp_path / "inst")
+        os.makedirs(d)
+        m.Session = _session_found(d)
+        m._get_stellar_sdk = lambda: (True, None)
+
+    def test_returns_fee_and_resources(self, client, tmp_path):
+        self._setup(tmp_path)
+
+        sim = _sim_response(resource_fee=7500, cpu_insns="2500000", mem_bytes="640000")
+
+        with patch("stellar_sdk.Keypair.from_public_key"), \
+             patch("stellar_sdk.SorobanServer") as MockServer:
+            srv = MockServer.return_value
+            srv.load_account.return_value = MagicMock()
+            srv.simulate_transaction.return_value = sim
+
+            with patch("stellar_sdk.TransactionBuilder") as MockTxB:
+                MockTxB.return_value.set_timeout.return_value.append_invoke_contract_function_op \
+                    .return_value.build.return_value = MagicMock()
+
+                resp = client.post("/api/soroban/simulate/invoke", json={
+                    "session_id": 1,
+                    "contract_id": "CTEST123",
+                    "function_name": "balance",
+                    "invoker_public_key": self._VALID_PUBKEY,
+                    "parameters": [],
+                    "network": "testnet",
+                })
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+
+        fee = data["fee"]
+        assert fee["base_fee"] == 100
+        assert fee["resource_fee"] == 7500
+        assert fee["total_stroops"] == 7600
+        assert "XLM" not in fee["xlm"]  # just the number
+        assert float(fee["xlm"]) > 0
+
+        resources = data["resources"]
+        assert resources["cpu_insns"] == 2500000
+        assert resources["mem_bytes"] == 640000
+
+        assert data["network"] == "testnet"
+
+    def test_empty_parameters_accepted(self, client, tmp_path):
+        self._setup(tmp_path)
+        sim = _sim_response()
+
+        with patch("stellar_sdk.Keypair.from_public_key"), \
+             patch("stellar_sdk.SorobanServer") as MockServer, \
+             patch("stellar_sdk.TransactionBuilder") as MockTxB:
+
+            MockServer.return_value.load_account.return_value = MagicMock()
+            MockServer.return_value.simulate_transaction.return_value = sim
+            MockTxB.return_value.set_timeout.return_value \
+                .append_invoke_contract_function_op.return_value.build.return_value = MagicMock()
+
+            resp = client.post("/api/soroban/simulate/invoke", json={
+                "session_id": 1,
+                "contract_id": "CTEST",
+                "function_name": "get_count",
+                "invoker_public_key": self._VALID_PUBKEY,
+            })
+
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+
+    def test_simulation_error_propagated(self, client, tmp_path):
+        self._setup(tmp_path)
+        sim = _sim_response(error="HostError: value not found")
+
+        with patch("stellar_sdk.Keypair.from_public_key"), \
+             patch("stellar_sdk.SorobanServer") as MockServer, \
+             patch("stellar_sdk.TransactionBuilder") as MockTxB:
+
+            MockServer.return_value.load_account.return_value = MagicMock()
+            MockServer.return_value.simulate_transaction.return_value = sim
+            MockTxB.return_value.set_timeout.return_value \
+                .append_invoke_contract_function_op.return_value.build.return_value = MagicMock()
+
+            resp = client.post("/api/soroban/simulate/invoke", json={
+                "session_id": 1,
+                "contract_id": "CTEST",
+                "function_name": "missing_fn",
+                "invoker_public_key": self._VALID_PUBKEY,
+            })
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert "HostError" in data["simulation_error"]
+
+    def test_rpc_error_returns_502(self, client, tmp_path):
+        self._setup(tmp_path)
+
+        with patch("stellar_sdk.Keypair.from_public_key"), \
+             patch("stellar_sdk.SorobanServer") as MockServer, \
+             patch("stellar_sdk.TransactionBuilder") as MockTxB:
+
+            MockServer.return_value.load_account.return_value = MagicMock()
+            MockServer.return_value.simulate_transaction.side_effect = Exception("connection refused")
+            MockTxB.return_value.set_timeout.return_value \
+                .append_invoke_contract_function_op.return_value.build.return_value = MagicMock()
+
+            resp = client.post("/api/soroban/simulate/invoke", json={
+                "session_id": 1,
+                "contract_id": "CTEST",
+                "function_name": "hello",
+                "invoker_public_key": self._VALID_PUBKEY,
+            })
+
+        assert resp.status_code == 502
+
+    def test_account_not_found_returns_422(self, client, tmp_path):
+        self._setup(tmp_path)
+
+        with patch("stellar_sdk.Keypair.from_public_key"), \
+             patch("stellar_sdk.SorobanServer") as MockServer, \
+             patch("stellar_sdk.TransactionBuilder"):
+
+            MockServer.return_value.load_account.side_effect = Exception("not found")
+
+            resp = client.post("/api/soroban/simulate/invoke", json={
+                "session_id": 1,
+                "contract_id": "CTEST",
+                "function_name": "hello",
+                "invoker_public_key": self._VALID_PUBKEY,
+            })
+
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /api/soroban/simulate/deploy — input validation
+# ---------------------------------------------------------------------------
+
+class TestSimulateDeployValidation:
+    def test_missing_session_id(self, client):
+        resp = client.post("/api/soroban/simulate/deploy", json={
+            "wasm_path": "contract.wasm",
+            "deployer_public_key": "G" + "A" * 55,
+        })
+        assert resp.status_code == 400
+        assert "session_id" in resp.get_json()["error"]
+
+    def test_missing_wasm_path(self, client):
+        resp = client.post("/api/soroban/simulate/deploy", json={
+            "session_id": 1,
+            "deployer_public_key": "G" + "A" * 55,
+        })
+        assert resp.status_code == 400
+        assert "wasm_path" in resp.get_json()["error"]
+
+    def test_missing_deployer_public_key(self, client):
+        resp = client.post("/api/soroban/simulate/deploy", json={
+            "session_id": 1,
+            "wasm_path": "contract.wasm",
+        })
+        assert resp.status_code == 400
+        assert "deployer_public_key" in resp.get_json()["error"]
+
+    def test_session_not_found(self, client):
+        m.Session = _session_not_found()
+        resp = client.post("/api/soroban/simulate/deploy", json={
+            "session_id": 99,
+            "wasm_path": "contract.wasm",
+            "deployer_public_key": "G" + "A" * 55,
+        })
+        assert resp.status_code == 404
+
+    def test_wasm_file_not_found(self, client, tmp_path):
+        d = str(tmp_path / "inst")
+        os.makedirs(d)
+        m.Session = _session_found(d)
+        m._get_stellar_sdk = lambda: (True, None)
+
+        deploy_stub = MagicMock()
+        deploy_stub._resolve_wasm_path.return_value = None
+
+        with patch.dict("sys.modules", {"server.routes.soroban_deploy": deploy_stub}):
+            resp = client.post("/api/soroban/simulate/deploy", json={
+                "session_id": 1,
+                "wasm_path": "nonexistent.wasm",
+                "deployer_public_key": "G" + "A" * 55,
+            })
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /api/soroban/simulate/deploy — happy path
+# ---------------------------------------------------------------------------
+
+class TestSimulateDeploySuccess:
+    _VALID_PUBKEY = "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV73AAUG4HA"
+
+    def test_returns_upload_fee_and_wasm_size(self, client, tmp_path):
+        d = str(tmp_path / "inst")
+        os.makedirs(d)
+
+        wasm_file = tmp_path / "inst" / "contract.wasm"
+        wasm_bytes = b"\x00asm" + b"\x00" * 100
+        wasm_file.write_bytes(wasm_bytes)
+
+        m.Session = _session_found(d)
+        m._get_stellar_sdk = lambda: (True, None)
+
+        deploy_stub = MagicMock()
+        deploy_stub._resolve_wasm_path.return_value = str(wasm_file)
+
+        sim = _sim_response(resource_fee=12000)
+
+        with patch.dict("sys.modules", {"server.routes.soroban_deploy": deploy_stub}), \
+             patch("stellar_sdk.Keypair.from_public_key"), \
+             patch("stellar_sdk.SorobanServer") as MockServer, \
+             patch("stellar_sdk.TransactionBuilder") as MockTxB:
+
+            MockServer.return_value.load_account.return_value = MagicMock()
+            MockServer.return_value.simulate_transaction.return_value = sim
+            MockTxB.return_value.set_timeout.return_value \
+                .append_upload_contract_wasm_op.return_value.build.return_value = MagicMock()
+
+            resp = client.post("/api/soroban/simulate/deploy", json={
+                "session_id": 1,
+                "wasm_path": "contract.wasm",
+                "deployer_public_key": self._VALID_PUBKEY,
+            })
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["wasm_size_bytes"] == len(wasm_bytes)
+        assert data["upload_fee"]["resource_fee"] == 12000
+        assert data["upload_fee"]["total_stroops"] == 12100
+        assert data["network"] == "testnet"
+        assert "note" in data
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _decode_sim_response
+# ---------------------------------------------------------------------------
+
+class TestDecodeSimResponse:
+    def test_extracts_resource_fee(self):
+        sim = _sim_response(resource_fee=9999)
+        result = m._decode_sim_response(sim)
+        assert result["resource_fee"] == 9999
+
+    def test_extracts_cpu_and_mem(self):
+        sim = _sim_response(cpu_insns="3000000", mem_bytes="1024000")
+        result = m._decode_sim_response(sim)
+        assert result["cpu_insns"] == 3000000
+        assert result["mem_bytes"] == 1024000
+
+    def test_sim_error_propagated(self):
+        sim = _sim_response(error="some error")
+        result = m._decode_sim_response(sim)
+        assert result["sim_error"] == "some error"
+
+    def test_no_results_means_no_simulated_result(self):
+        sim = _sim_response(results=[])
+        result = m._decode_sim_response(sim)
+        assert result["simulated_result"] is None
+        assert result["auth_entries"] == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _parse_param
+# ---------------------------------------------------------------------------
+
+class TestParseParam:
+    def test_u32(self):
+        from stellar_sdk import scval
+        assert m._parse_param("u32:42") == scval.to_uint32(42)
+
+    def test_u64(self):
+        from stellar_sdk import scval
+        assert m._parse_param("u64:99999999") == scval.to_uint64(99999999)
+
+    def test_i32(self):
+        from stellar_sdk import scval
+        assert m._parse_param("i32:-5") == scval.to_int32(-5)
+
+    def test_bool_true(self):
+        from stellar_sdk import scval
+        assert m._parse_param("bool:true") == scval.to_bool(True)
+
+    def test_bool_false(self):
+        from stellar_sdk import scval
+        assert m._parse_param("bool:false") == scval.to_bool(False)
+
+    def test_sym(self):
+        from stellar_sdk import scval
+        assert m._parse_param("sym:transfer") == scval.to_symbol("transfer")
+
+    def test_str_prefix(self):
+        from stellar_sdk import scval
+        assert m._parse_param("str:hello") == scval.to_string("hello")
+
+    def test_default_falls_back_to_string(self):
+        from stellar_sdk import scval
+        assert m._parse_param("plain") == scval.to_string("plain")
+
+    def test_bytes(self):
+        from stellar_sdk import scval
+        assert m._parse_param("bytes:deadbeef") == scval.to_bytes(bytes.fromhex("deadbeef"))
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _fee_summary
+# ---------------------------------------------------------------------------
+
+class TestFeeSummary:
+    def test_total_is_base_plus_resource(self):
+        result = m._fee_summary(5000)
+        assert result["base_fee"] == 100
+        assert result["resource_fee"] == 5000
+        assert result["total_stroops"] == 5100
+
+    def test_xlm_conversion(self):
+        result = m._fee_summary(0)
+        assert result["xlm"] == "0.0000100"
+
+    def test_zero_resource_fee(self):
+        result = m._fee_summary(0)
+        assert result["total_stroops"] == 100


### PR DESCRIPTION
## Summary

- **Pre-flight simulation** (`POST /api/soroban/simulate/invoke`, `POST /api/soroban/simulate/deploy`): calls `SorobanServer.simulate_transaction()` against Stellar testnet/mainnet and returns fee breakdown (base + resource fees in stroops/XLM) plus resource usage (CPU instructions, memory, ledger read/write bytes) without submitting anything on-chain. Supports typed SCVal parameters (`u32`, `u64`, `i32`, `i64`, `bool`, `address`, `bytes`, `sym`, `str`).

- **Contract event log** (`GET /api/soroban/events/<session_id>`): decodes `TransactionMetaV3.soroban_meta.events` from `result_meta_xdr` after each invocation, filters DIAGNOSTIC events, converts SCVal topics and data to Python types, persists events in per-invocation JSON records, supports filtering by `contract_id`.

- **Bug fix**: `soroban_prompts_bp` was imported in `start.py` but never registered — all `/api/prompts/soroban/*` endpoints were silently returning 404.

- **Bug fix**: login form sent field `email` but backend expects `login`, breaking sign-in for all users.

- `SimulationPanel` and `ContractEventLog` React components wired into the IDE sidebar.

- 70 tests covering all new endpoints and helpers.

## Test plan

- [x] `python -m pytest server/tests/test_soroban_simulate.py server/tests/test_soroban_invoke.py -v` — 70 tests pass
- [x] `POST /api/soroban/simulate/invoke` with a funded testnet account returns fee estimate + resource usage
- [x] `GET /api/soroban/events/<session_id>` returns empty list before invocations, decoded events after
- [x] Login with email works after field name fix
- [x] Sim and Events tabs visible in IDE sidebar
